### PR TITLE
Improve load_rois Path handling

### DIFF
--- a/utils/roi.py
+++ b/utils/roi.py
@@ -15,20 +15,20 @@ Rect = Tuple[int, int, int, int]  # (left, top, width, height)
 
 def load_rois(zip_path: Path | str) -> List[Rect]:
     """ImageJ ROI zip (or .roi) → [(x,y,w,h), ...]"""
-    rects = []
-    if not zip_path.exists():
-        raise FileNotFoundError(f"ROI file not found: {zip_path}")
-    else:
-        rz = roifile.roiread(zip_path)
-        if not isinstance(rz, list):
-            rz = [rz]
-        for r in rz:
-            l, t = int(r.left), int(r.top)
-            w = int(getattr(r, "width", r.right - r.left))
-            h = int(getattr(r, "height", r.bottom - r.top))
-            rects.append((l, t, w, h))
-        if not rects:
-            raise ValueError(f"Invalid ROI file: {zip_path}")
+    path = Path(zip_path)
+    rects: List[Rect] = []
+    if not path.exists():
+        raise FileNotFoundError(f"ROI file not found: {path}")
+    rz = roifile.roiread(str(path))
+    if not isinstance(rz, list):
+        rz = [rz]
+    for r in rz:
+        l, t = int(r.left), int(r.top)
+        w = int(getattr(r, "width", r.right - r.left))
+        h = int(getattr(r, "height", r.bottom - r.top))
+        rects.append((l, t, w, h))
+    if not rects:
+        raise ValueError(f"Invalid ROI file: {path}")
     # print(f"ROI count: {len(rects)}, {rects}")
     return rects
 


### PR DESCRIPTION
## Summary
- support both `str` and `Path` for ROI loader

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`