### PR TITLE
Implement ROI-aware pseudo PRNU

### DIFF
--- a/core/analysis.py
+++ b/core/analysis.py
@@ -213,12 +213,56 @@ def calculate_dynamic_range_dn(dn_sat: float, read_noise: float) -> float:
     return 20.0 * np.log10(dn_sat / read_noise)
 
 
-def calculate_pseudo_prnu(flat_stack: np.ndarray, cfg: Dict[str, Any]) -> Tuple[float, np.ndarray]:
-    """Return (prnu_percent, residual_map)."""
+def calculate_pseudo_prnu(
+    flat_stack: np.ndarray,
+    cfg: Dict[str, Any],
+    rects: list[tuple[int, int, int, int]] | None = None,
+) -> Tuple[float, np.ndarray]:
+    """Return (pseudo_prnu_percent, residual_map) within ROI."""
+
+    mask = (
+        _mask_from_rects(flat_stack.shape[1:], rects)
+        if rects
+        else np.ones(flat_stack.shape[1:], bool)
+    )
+
     mean_frame = np.mean(flat_stack, axis=0)
-    std_frame = np.std(flat_stack, axis=0)
-    stat_mode = cfg["processing"].get("stat_mode", "rms")
-    value = _reduce(std_frame, stat_mode) / max(mean_frame.mean(), 1e-6) * 100.0
+
+    apply_gain = cfg.get("processing", {}).get("apply_gain_map", False)
+    order = int(cfg.get("processing", {}).get("plane_fit_order", 0))
+
+    def _fit_gain(frame: np.ndarray, mask: np.ndarray, order: int) -> np.ndarray:
+        if order <= 0:
+            c = float(np.mean(frame[mask]))
+            return np.full_like(frame, c)
+        y, x = np.indices(frame.shape)
+        xm, ym = x[mask].ravel(), y[mask].ravel()
+        z = frame[mask].ravel()
+        cols = []
+        for i in range(order + 1):
+            for j in range(order + 1 - i):
+                cols.append((xm ** i) * (ym ** j))
+        A = np.vstack(cols).T
+        coef, *_ = np.linalg.lstsq(A, z, rcond=None)
+        cols_full = []
+        for i in range(order + 1):
+            for j in range(order + 1 - i):
+                cols_full.append((x ** i) * (y ** j))
+        A_full = np.stack(cols_full, axis=0)
+        fitted = np.tensordot(coef, A_full, axes=(0, 0))
+        return fitted
+
+    if apply_gain:
+        gain_map = _fit_gain(mean_frame, mask, order)
+        gain_map = np.where(gain_map == 0, 1e-6, gain_map)
+        corrected = flat_stack / gain_map
+        mean_frame = np.mean(corrected, axis=0)
+        std_frame = np.std(corrected, axis=0)
+    else:
+        std_frame = np.std(flat_stack, axis=0)
+
+    stat_mode = cfg.get("processing", {}).get("stat_mode", "rms")
+    value = _reduce(std_frame[mask], stat_mode) / max(mean_frame[mask].mean(), 1e-6) * 100.0
     return value, std_frame
 
 

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -41,6 +41,7 @@ from core.plotting import (
     plot_prnu_regression,
     plot_heatmap,
 )
+from utils.roi import load_rois
 from core.report_gen import save_summary_txt, report_csv, report_html
 from core.loader import load_image_stack
 
@@ -77,6 +78,8 @@ def run_pipeline(project: Path, cfg: Dict[str, Any]) -> Dict[str, float]:
     ratios = np.array([kv[0][1] for kv in tuples])
 
     roi_table = extract_roi_table(project, cfg)
+    flat_roi_file = project / cfg["measurement"].get("flat_roi_file")
+    flat_rects = load_rois(flat_roi_file)
 
     # 2. Dark/flat metrics per gain (use first gain for maps)
     debug_stacks = cfg["output"].get("debug_stacks", False)
@@ -100,7 +103,7 @@ def run_pipeline(project: Path, cfg: Dict[str, Any]) -> Dict[str, float]:
             dark_stack = load_image_stack(dark_folder)
             tifffile.imwrite(out_dir / f"dark_cache_{int(gain_db)}dB.tiff", dark_stack)
             tifffile.imwrite(out_dir / f"flat_cache_{int(gain_db)}dB.tiff", flat_stack)
-        prnu, prnu_map_tmp = calculate_pseudo_prnu(flat_stack, cfg)
+        prnu, prnu_map_tmp = calculate_pseudo_prnu(flat_stack, cfg, flat_rects)
         prnu_list.append(prnu)
         sens_list.append(calculate_system_sensitivity(flat_stack, cfg))
         if first:
@@ -122,7 +125,7 @@ def run_pipeline(project: Path, cfg: Dict[str, Any]) -> Dict[str, float]:
         "DSNU (DN)": dsnu,
         "Read Noise (DN)": read_noise,
         "DN_sat": dn_sat,
-        "PRNU (%)": prnu,
+        "Pseudo PRNU (%)": prnu,
         "System Sensitivity": system_sens,
         "DN @ 10 dB": dn_at_10,
     }


### PR DESCRIPTION
## Summary
- load ROI rectangles in pipeline and pass to PRNU calculation
- rename PRNU output field to `Pseudo PRNU (%)`
- support ROI mask and gain-map correction in `calculate_pseudo_prnu`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`