### PR TITLE
Add SNR@50% and DN@0dB metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ python -m sensor_eval
         •       🗺 prnu_residual_map.png: PRNU residual map
         •       📋 summary.txt: Key evaluation metrics
         •       📄 report.html: Embedded HTML report
+        •       📌 Metrics include SNR @ 50% and DN @ SNR=1 (0 dB)
         •       📑 roi_stats.csv: (Planned) Per-condition stats
 
 ##🔮 Planned Features

--- a/config/default_config.yaml
+++ b/config/default_config.yaml
@@ -62,7 +62,11 @@ output:
   debug_stacks: false
   report_order:
     - Dynamic Range (dB)
-    - SNR (max)
-    - Read Noise
-    - DN @ 20 dB
+    - SNR @ 50% (dB)
+    - DN @ 10 dB
+    - DN @ 0 dB
+    - Read Noise (DN)
+    - DSNU (DN)
+    - DN_sat
     - PRNU (%)
+    - System Sensitivity

--- a/core/analysis.py
+++ b/core/analysis.py
@@ -24,6 +24,8 @@ __all__ = [
     "calculate_dynamic_range_dn",
     "calculate_system_sensitivity",
     "calculate_dn_at_snr",
+    "calculate_snr_at_half",
+    "calculate_dn_at_snr_one",
     "calculate_pseudo_prnu",
 ]
 
@@ -248,3 +250,22 @@ def calculate_dn_at_snr(signal: np.ndarray, snr_lin: np.ndarray, threshold_db: f
         return float(x1)
     r = (thr_lin - y0) / (y1 - y0)
     return float(x0 + r * (x1 - x0))
+
+
+def calculate_snr_at_half(signal: np.ndarray, snr_lin: np.ndarray, dn_sat: float) -> float:
+    """Return SNR (dB) at half of DN_sat using linear interpolation."""
+    if signal.size == 0:
+        return float("nan")
+    order = np.argsort(signal)
+    sig_sorted = signal[order]
+    snr_sorted = snr_lin[order]
+    target = 0.5 * dn_sat
+    snr_val = float(np.interp(target, sig_sorted, snr_sorted))
+    if snr_val <= 0:
+        return float("nan")
+    return float(20.0 * np.log10(snr_val))
+
+
+def calculate_dn_at_snr_one(signal: np.ndarray, snr_lin: np.ndarray) -> float:
+    """Convenience for DN where SNR=1 (0 dB)."""
+    return calculate_dn_at_snr(signal, snr_lin, 0.0)

--- a/core/report_gen.py
+++ b/core/report_gen.py
@@ -50,10 +50,14 @@ def report_html(summary: Dict[str, float], graphs: Dict[str, Path], cfg: Dict[st
 
     order = cfg.get("output", {}).get("report_order", [
         "Dynamic Range (dB)",
-        "SNR (max)",
-        "Read Noise",
-        "DN @ 20 dB",
+        "SNR @ 50% (dB)",
+        "DN @ 10 dB",
+        "DN @ 0 dB",
+        "Read Noise (DN)",
+        "DSNU (DN)",
+        "DN_sat",
         "PRNU (%)",
+        "System Sensitivity",
     ])
 
     rows = "".join(

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -33,6 +33,8 @@ from core.analysis import (
     calculate_dynamic_range_dn,
     calculate_system_sensitivity,
     calculate_dn_at_snr,
+    calculate_snr_at_half,
+    calculate_dn_at_snr_one,
     calculate_pseudo_prnu,
 )
 from core.plotting import (
@@ -114,6 +116,8 @@ def run_pipeline(project: Path, cfg: Dict[str, Any]) -> Dict[str, float]:
     prnu = float(np.mean(prnu_list)) if prnu_list else float('nan')
     system_sens = float(np.mean(sens_list)) if sens_list else float('nan')
     dn_at_10 = calculate_dn_at_snr(signals, snr_lin, cfg["processing"].get("snr_threshold_dB", 10.0))
+    snr_at_50 = calculate_snr_at_half(signals, snr_lin, dn_sat)
+    dn_at_0 = calculate_dn_at_snr_one(signals, snr_lin)
 
     stats_rows = roi_table
     report_csv(stats_rows, cfg, out_dir / "roi_stats.csv")
@@ -125,6 +129,8 @@ def run_pipeline(project: Path, cfg: Dict[str, Any]) -> Dict[str, float]:
         "PRNU (%)": prnu,
         "System Sensitivity": system_sens,
         "DN @ 10 dB": dn_at_10,
+        "SNR @ 50% (dB)": snr_at_50,
+        "DN @ 0 dB": dn_at_0,
     }
     save_summary_txt(summary, cfg, out_dir / "summary.txt")
 


### PR DESCRIPTION
## Summary
- implement `calculate_snr_at_half` and `calculate_dn_at_snr_one`
- compute new metrics in pipeline and show them in reports
- adjust default report order accordingly
- document the metrics in README

## Testing
- `python -m pytest`