### PR TITLE
Fix matplotlib warnings in threaded plotting

### DIFF
--- a/core/plotting.py
+++ b/core/plotting.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Dict, Any, Sequence
 
+import matplotlib
+matplotlib.use("Agg")  # avoid GUI backend so plotting works inside threads
 import matplotlib.pyplot as plt
 import numpy as np
 


### PR DESCRIPTION
## Summary
- use `matplotlib.use("Agg")` before importing pyplot

## Testing
- `pytest -q`