### PR TITLE
Add basic pytest suite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = ["pytest>=8.0"]
+tests = ["pytest>=8.0"]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,0 +1,62 @@
+import sys
+import types
+import importlib
+
+import pytest
+
+pytest.importorskip('numpy')
+pytest.importorskip('tifffile')
+
+import numpy as np
+import tifffile
+
+# provide roifile stub before importing modules that require it
+class _StubROI:
+    left = 0
+    top = 0
+    width = 2
+    height = 2
+
+
+def _roiread(path):
+    return [_StubROI()]
+
+sys.modules['roifile'] = types.SimpleNamespace(roiread=_roiread)
+
+from utils.config import load_config
+import utils.roi as roi  # reload with stubbed roifile
+importlib.reload(roi)
+import core.analysis as analysis
+importlib.reload(analysis)
+
+
+def test_calculate_dark_noise_gain(tmp_path):
+    project = tmp_path
+    gain_dir = project / 'gain_0dB' / 'dark'
+    gain_dir.mkdir(parents=True)
+
+    for i in range(2):
+        tifffile.imwrite(gain_dir / f'frame{i}.tiff', np.full((2, 2), i, dtype=np.uint16))
+
+    roi_file = project / 'roi.roi'
+    roi_file.write_text('dummy')
+
+    cfg_data = {
+        'measurement': {
+            'gains': {0: {'folder': 'gain_0dB'}},
+            'flat_roi_file': str(roi_file),
+        }
+    }
+    cfg_file = project / 'config.yaml'
+    with cfg_file.open('w') as fh:
+        import yaml
+        yaml.safe_dump(cfg_data, fh)
+
+    cfg = load_config(cfg_file)
+
+    dsnu, rn, dsnu_map, rn_map = analysis.calculate_dark_noise_gain(project, 0, cfg)
+
+    assert pytest.approx(dsnu, abs=1e-6) == 0.0
+    assert pytest.approx(rn, abs=1e-6) == 0.5
+    assert dsnu_map.shape == (2, 2)
+    assert rn_map.shape == (2, 2)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,51 @@
+import tempfile
+from pathlib import Path
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+from utils.config import load_config, gain_entries
+
+
+def test_load_config_merges_defaults(tmp_path):
+    project_cfg = {
+        'measurement': {
+            'gains': {0: {'folder': 'g0_custom'}},
+            'exposures': {1.0: {'folder': 'exp1_custom'}},
+        },
+        'processing': {
+            'snr_threshold_dB': 25,
+        },
+    }
+    cfg_file = tmp_path / 'config.yaml'
+    with cfg_file.open('w', encoding='utf-8') as fh:
+        yaml.safe_dump(project_cfg, fh)
+
+    cfg = load_config(cfg_file)
+
+    # project override applied
+    assert cfg['measurement']['gains']['0']['folder'] == 'g0_custom'
+    assert cfg['measurement']['exposures']['1.0']['folder'] == 'exp1_custom'
+    assert cfg['processing']['snr_threshold_dB'] == 25
+
+    # default values preserved
+    assert cfg['measurement']['gains']['6']['folder'] == 'gain_6dB'
+    assert cfg['processing']['min_sig_factor'] == 3
+
+
+def test_gain_entries_sorted():
+    cfg = {
+        'measurement': {
+            'gains': {
+                '6': {'folder': 'g6'},
+                '0': {'folder': 'g0'},
+                '12': {'folder': 'g12'},
+            }
+        }
+    }
+    entries = gain_entries(cfg)
+    assert entries == [
+        (0.0, 'g0'),
+        (6.0, 'g6'),
+        (12.0, 'g12'),
+    ]


### PR DESCRIPTION
## Summary
- add optional `tests` extras group
- add pytest covering config utilities
- add pytest covering dark noise analysis

## Testing
- `pytest -q` *(fails: 2 skipped because required packages are missing)*