### PR TITLE
Validate SNR plotting inputs

### DIFF
--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,0 +1,19 @@
+import pytest
+
+np = pytest.importorskip("numpy")
+
+from core import plotting
+
+
+def test_plot_snr_vs_signal_invalid(tmp_path):
+    sig = np.array([1.0, 0.0, 3.0])
+    snr = np.array([1.0, 2.0, 3.0])
+    with pytest.raises(ValueError):
+        plotting.plot_snr_vs_signal(sig, snr, {}, tmp_path / "out.png")
+
+
+def test_plot_snr_vs_exposure_invalid(tmp_path):
+    data = {0.0: (np.array([1.0, -2.0]), np.array([1.0, 2.0]))}
+    with pytest.raises(ValueError):
+        plotting.plot_snr_vs_exposure(data, {}, tmp_path / "out.png")
+


### PR DESCRIPTION
## Summary
- add `_validate_positive_finite` helper for plotting
- validate all arrays in `plot_snr_vs_signal` and `plot_snr_vs_exposure`
- test for invalid data handling

## Testing
- `pytest -q` *(fails: 3 skipped)*