### PR TITLE
Gain dependent exposure ratio

### DIFF
--- a/core/plotting.py
+++ b/core/plotting.py
@@ -73,7 +73,10 @@ def plot_snr_vs_exposure(
     plot_cfg = cfg.get("plot", {})
     labels = plot_cfg.get("exposures")
     if labels is None:
-        labels = [ratio for ratio, _ in cfgutil.exposure_entries(cfg)]
+        try:
+            labels = [ratio for ratio, _ in cfgutil.exposure_entries(cfg)]
+        except KeyError:
+            labels = []
     label_strs = _auto_labels(labels)
 
     base_ms = float(cfg.get("illumination", {}).get("exposure_ms", 1.0))

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -148,8 +148,12 @@ def run_pipeline(project: Path, cfg: Dict[str, Any]) -> Dict[str, float]:
                         out_dir / f"flat_cache_{int(gain_db)}dB.tiff", flat_stack
                     )
                 prnu, prnu_map_tmp = calculate_pseudo_prnu(flat_stack, cfg, flat_rects)
+                gain_mult = cfgutil.gain_ratio(gain_db)
                 sens = calculate_system_sensitivity(
-                    flat_stack, cfg, flat_rects, ratio=1.0
+                    flat_stack,
+                    cfg,
+                    flat_rects,
+                    ratio=1.0 / gain_mult,
                 )
                 if first:
                     dsnu_map, rn_map, prnu_map = dsnu_map_tmp, rn_map_tmp, prnu_map_tmp

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,48 +5,53 @@ import pytest
 
 yaml = pytest.importorskip("yaml")
 
-from utils.config import load_config, gain_entries
+from utils.config import load_config, gain_entries, gain_ratio
 
 
 def test_load_config_merges_defaults(tmp_path):
     project_cfg = {
-        'measurement': {
-            'gains': {0: {'folder': 'g0_custom'}},
-            'exposures': {1.0: {'folder': 'exp1_custom'}},
+        "measurement": {
+            "gains": {0: {"folder": "g0_custom"}},
+            "exposures": {1.0: {"folder": "exp1_custom"}},
         },
-        'processing': {
-            'snr_threshold_dB': 25,
+        "processing": {
+            "snr_threshold_dB": 25,
         },
     }
-    cfg_file = tmp_path / 'config.yaml'
-    with cfg_file.open('w', encoding='utf-8') as fh:
+    cfg_file = tmp_path / "config.yaml"
+    with cfg_file.open("w", encoding="utf-8") as fh:
         yaml.safe_dump(project_cfg, fh)
 
     cfg = load_config(cfg_file)
 
     # project override applied
-    assert cfg['measurement']['gains']['0']['folder'] == 'g0_custom'
-    assert cfg['measurement']['exposures']['1.0']['folder'] == 'exp1_custom'
-    assert cfg['processing']['snr_threshold_dB'] == 25
+    assert cfg["measurement"]["gains"]["0"]["folder"] == "g0_custom"
+    assert cfg["measurement"]["exposures"]["1.0"]["folder"] == "exp1_custom"
+    assert cfg["processing"]["snr_threshold_dB"] == 25
 
     # default values preserved
-    assert cfg['measurement']['gains']['6']['folder'] == 'gain_6dB'
-    assert cfg['processing']['min_sig_factor'] == 3
+    assert cfg["measurement"]["gains"]["6"]["folder"] == "gain_6dB"
+    assert cfg["processing"]["min_sig_factor"] == 3
 
 
 def test_gain_entries_sorted():
     cfg = {
-        'measurement': {
-            'gains': {
-                '6': {'folder': 'g6'},
-                '0': {'folder': 'g0'},
-                '12': {'folder': 'g12'},
+        "measurement": {
+            "gains": {
+                "6": {"folder": "g6"},
+                "0": {"folder": "g0"},
+                "12": {"folder": "g12"},
             }
         }
     }
     entries = gain_entries(cfg)
     assert entries == [
-        (0.0, 'g0'),
-        (6.0, 'g6'),
-        (12.0, 'g12'),
+        (0.0, "g0"),
+        (6.0, "g6"),
+        (12.0, "g12"),
     ]
+
+
+def test_gain_ratio_conversion():
+    assert gain_ratio(0.0) == 1.0
+    assert pytest.approx(gain_ratio(6.0), abs=1e-6) == 10 ** (6.0 / 20.0)

--- a/utils/config.py
+++ b/utils/config.py
@@ -13,6 +13,7 @@ __all__ = [
     "exposure_entries",
     "find_gain_folder",
     "find_exposure_folder",
+    "gain_ratio",
 ]
 
 # ────────────────────────────────────────────────
@@ -20,9 +21,11 @@ __all__ = [
 # ────────────────────────────────────────────────
 _DEFAULT_CFG_PATH = Path(__file__).parent.parent / "config" / "default_config.yaml"
 
+
 def _read_yaml(path: Path) -> Dict[str, Any]:
     with path.open("r", encoding="utf-8") as fh:
         return yaml.safe_load(fh) or {}
+
 
 def _merge_dict(dst: Dict[str, Any], src: Dict[str, Any]) -> Dict[str, Any]:
     """Recursive dict merge (src overwrites dst)."""
@@ -33,6 +36,7 @@ def _merge_dict(dst: Dict[str, Any], src: Dict[str, Any]) -> Dict[str, Any]:
             dst[k] = v
     return dst
 
+
 def load_config(project_cfg_path: Path | str) -> Dict[str, Any]:
     """Return merged config dict (default <- project)."""
     default_cfg = _read_yaml(_DEFAULT_CFG_PATH)
@@ -40,7 +44,15 @@ def load_config(project_cfg_path: Path | str) -> Dict[str, Any]:
     if project_yaml.is_dir():
         project_yaml = project_yaml / "config.yaml"
     project_cfg = _read_yaml(project_yaml)
-    return _merge_dict(default_cfg, project_cfg)
+    cfg = _merge_dict(default_cfg, project_cfg)
+    meas = cfg.get("measurement", {})
+    if "gains" in meas:
+        meas["gains"] = {str(k): v for k, v in meas["gains"].items()}
+    if "exposures" in meas:
+        meas["exposures"] = {str(k): v for k, v in meas["exposures"].items()}
+    cfg["measurement"] = meas
+    return cfg
+
 
 # ────────────────────────────────────────────────
 # Measurement helpers (nested-dict access)
@@ -49,17 +61,17 @@ def gain_entries(cfg: Dict[str, Any]) -> List[Tuple[float, str]]:
     """Return sorted list of (gain_db, folder)."""
     gains = cfg["measurement"]["gains"]
     return sorted(
-        [(float(db), meta["folder"]) for db, meta in gains.items()],
-        key=lambda x: x[0]
+        [(float(db), meta["folder"]) for db, meta in gains.items()], key=lambda x: x[0]
     )
+
 
 def exposure_entries(cfg: Dict[str, Any]) -> List[Tuple[float, str]]:
     """Return sorted list of (ratio, folder) descending by ratio."""
     exps = cfg["measurement"]["exposures"]
     return sorted(
-        [(float(r), meta["folder"]) for r, meta in exps.items()],
-        key=lambda x: -x[0]
+        [(float(r), meta["folder"]) for r, meta in exps.items()], key=lambda x: -x[0]
     )
+
 
 def _lookup_nested(d: Dict[str, Any], key: float | int) -> Dict[str, Any]:
     """Robustly fetch nested-dict item allowing float/int/str key variants."""
@@ -72,13 +84,25 @@ def _lookup_nested(d: Dict[str, Any], key: float | int) -> Dict[str, Any]:
         return d[str_key]
     raise KeyError(key)
 
-def find_gain_folder(project: Path | str, gain_db: float | int, cfg: Dict[str, Any]) -> Path:
+
+def find_gain_folder(
+    project: Path | str, gain_db: float | int, cfg: Dict[str, Any]
+) -> Path:
     """Return <project>/<gain_folder>. Accepts gain_db as float or int."""
     project = Path(project)
     folder = _lookup_nested(cfg["measurement"]["gains"], gain_db)["folder"]
     return project / folder
 
-def find_exposure_folder(project: Path | str, gain_db: float | int, ratio: float, cfg: Dict[str, Any]) -> Path:
+
+def find_exposure_folder(
+    project: Path | str, gain_db: float | int, ratio: float, cfg: Dict[str, Any]
+) -> Path:
     gain_path = find_gain_folder(project, gain_db, cfg)
     exp_folder = _lookup_nested(cfg["measurement"]["exposures"], ratio)["folder"]
     return gain_path / exp_folder
+
+
+def gain_ratio(gain_db: float) -> float:
+    """Return linear gain ratio from decibel value."""
+
+    return 10 ** (float(gain_db) / 20.0)

--- a/utils/roi.py
+++ b/utils/roi.py
@@ -24,11 +24,14 @@ def load_rois(zip_path: Path | str) -> List[Rect]:
         rz = [rz]
     for r in rz:
         l, t = int(r.left), int(r.top)
-        w = int(getattr(r, "width", r.right - r.left))
-        h = int(getattr(r, "height", r.bottom - r.top))
-        rects.append((l, t, w, h))
+        width = getattr(r, "width", None)
+        if width is None:
+            width = getattr(r, "right", 0) - getattr(r, "left", 0)
+        height = getattr(r, "height", None)
+        if height is None:
+            height = getattr(r, "bottom", 0) - getattr(r, "top", 0)
+        rects.append((l, t, int(width), int(height)))
     if not rects:
         raise ValueError(f"Invalid ROI file: {path}")
     # print(f"ROI count: {len(rects)}, {rects}")
     return rects
-


### PR DESCRIPTION
## Summary
- adjust `load_config` to normalize keys as strings and add a `gain_ratio` helper
- fix ROI loader for stub objects
- gracefully handle missing exposures in plotting
- compute exposure ratio from gain when calculating system sensitivity
- test gain ratio conversion

## Testing
- `pytest -q`