### PR TITLE
Fix inconsistent SNR-Signal graph

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -233,7 +233,7 @@ def run_pipeline(project: Path, cfg: Dict[str, Any]) -> Dict[str, float]:
                 "roi_mid_index", cfg.get("measurement", {}).get("roi_mid_index", 5)
             )
             exp_data = collect_mid_roi_snr(roi_table, mid_idx)
-            sig_data = collect_gain_snr_signal(stats)
+            sig_data = collect_gain_snr_signal(roi_table, cfg)
 
             plot_snr_vs_signal_multi(sig_data, cfg, out_dir / "snr_signal.png")
             plot_snr_vs_exposure(exp_data, cfg, out_dir / "snr_exposure.png")

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -75,3 +75,30 @@ def test_calculate_system_sensitivity_ratio():
     cfg = {"illumination": {"power_uW_cm2": 100.0, "exposure_ms": 50}}
     sens = analysis.calculate_system_sensitivity(stack, cfg, ratio=2.0)
     assert pytest.approx(sens, abs=1e-6) == 200.0 / (100.0 * 50 * 2.0 / 1000.0)
+
+
+def test_collect_gain_snr_signal_rows():
+    rows = [
+        {
+            "ROI Type": "grayscale",
+            "ROI No": 0,
+            "Gain (dB)": 0.0,
+            "Exposure": 1.0,
+            "Mean": 10.0,
+            "Std": 1.0,
+        },
+        {
+            "ROI Type": "flat",
+            "ROI No": "-",
+            "Gain (dB)": 0.0,
+            "Exposure": 1.0,
+            "Mean": 20.0,
+            "Std": 2.0,
+        },
+    ]
+    cfg = {"processing": {"exclude_abnormal_snr": False, "min_sig_factor": 0}}
+    data = analysis.collect_gain_snr_signal(rows, cfg)
+    assert 0.0 in data
+    sig, snr = data[0.0]
+    assert np.allclose(sig, [10.0, 20.0])
+    assert np.allclose(snr, [10.0, 10.0])


### PR DESCRIPTION
## Summary
- compute SNR-Signal curves from ROI table rows instead of aggregated stats
- adjust GUI pipeline to use the new API
- add unit test for `collect_gain_snr_signal`

## Testing
- `black core/analysis.py gui/main_window.py tests/test_analysis.py -q`
- `pytest -q` *(tests skipped)*