### PR TITLE
Enable gain-map correction for PRNU regression

### DIFF
--- a/core/analysis.py
+++ b/core/analysis.py
@@ -19,6 +19,7 @@ from core.loader import load_image_stack
 
 __all__ = [
     "extract_roi_stats",
+    "extract_roi_stats_gainmap",
     "extract_roi_table",
     "calculate_snr_curve",
     "calculate_dynamic_range",
@@ -128,6 +129,102 @@ def extract_roi_stats(
                 continue
             res[(gain_db, ratio)] = {"mean": mean, "std": std, "snr": snr}
     logging.info("Collected %d ROI stats", len(res))
+    return res
+
+
+def extract_roi_stats_gainmap(
+    project_dir: Path | str, cfg: Dict[str, Any]
+) -> Dict[Tuple[float, float], Dict[str, float]]:
+    """Compute ROI stats with gain-map correction applied."""
+    project_dir = Path(project_dir)
+    res: Dict[Tuple[float, float], Dict[str, float]] = {}
+
+    chart_roi_file = project_dir / cfg["measurement"]["chart_roi_file"]
+    flat_roi_file = project_dir / cfg["measurement"]["flat_roi_file"]
+    chart_rects = load_rois(chart_roi_file)
+    flat_rects = load_rois(flat_roi_file)
+
+    mid_idx = cfg.get("reference", {}).get(
+        "roi_mid_index", cfg.get("measurement", {}).get("roi_mid_index", 5)
+    )
+
+    snr_thresh = cfg["processing"].get("snr_threshold_dB", 10.0)
+    min_sig_factor = cfg["processing"].get("min_sig_factor", 3.0)
+    excl_low_snr = cfg["processing"].get("exclude_abnormal_snr", True)
+    debug_stacks = cfg["output"].get("debug_stacks", False)
+    order = int(cfg.get("processing", {}).get("plane_fit_order", 0))
+
+    def _fit_gain(frame: np.ndarray, mask: np.ndarray, order: int) -> np.ndarray:
+        if order <= 0:
+            c = float(np.mean(frame[mask]))
+            return np.full_like(frame, c)
+        y, x = np.indices(frame.shape)
+        xm, ym = x[mask].ravel(), y[mask].ravel()
+        z = frame[mask].ravel()
+        cols = []
+        for i in range(order + 1):
+            for j in range(order + 1 - i):
+                cols.append((xm**i) * (ym**j))
+        A = np.vstack(cols).T
+        coef, *_ = np.linalg.lstsq(A, z, rcond=None)
+        cols_full = []
+        for i in range(order + 1):
+            for j in range(order + 1 - i):
+                cols_full.append((x**i) * (y**j))
+        A_full = np.stack(cols_full, axis=0)
+        fitted = np.tensordot(coef, A_full, axes=(0, 0))
+        return fitted
+
+    for gain_db, gfold in cfgutil.gain_entries(cfg):
+        for ratio, efold in cfgutil.exposure_entries(cfg):
+            folder = project_dir / gfold / efold
+            if not folder.is_dir():
+                logging.info("Skipping missing folder: %s", folder)
+                continue
+            logging.info(
+                "Processing folder %s (%.1f dB, %.3fx)", folder, gain_db, ratio
+            )
+            stack = load_image_stack(folder)
+            if debug_stacks:
+                tifffile.imwrite(folder / "stack_cache.tiff", stack)
+
+            mean_frame = np.mean(stack, axis=0)
+            mask_fit = _mask_from_rects(stack.shape[1:], flat_rects)
+            gain_map = _fit_gain(mean_frame, mask_fit, order)
+            gain_map = np.where(gain_map == 0, 1e-6, gain_map)
+            corrected = stack / gain_map
+
+            rects = chart_rects if "chart" in efold.lower() else flat_rects
+            idx = mid_idx if "chart" in efold.lower() else 0
+            if idx >= len(rects):
+                idx = 0
+            mask = _mask_from_rects(stack.shape[1:], [rects[idx]])
+            pix = corrected[:, mask]
+            stat_mode = cfg["processing"].get("stat_mode", "rms")
+            mean = float(np.mean(pix))
+            noise_pix = np.std(pix, axis=0)
+            std = float(_reduce(noise_pix, stat_mode))
+            if std == 0:
+                logging.info("Skip due to zero std: %s", folder)
+                continue
+            if mean < min_sig_factor * std:
+                logging.info(
+                    "Skip due to low signal: mean %.2f < %.2f × %.2f",
+                    mean,
+                    min_sig_factor,
+                    std,
+                )
+                continue
+            snr = mean / std
+            if excl_low_snr and snr < snr_thresh:
+                logging.info(
+                    "Skip due to low SNR: %.2f dB < %.2f dB",
+                    20 * np.log10(snr),
+                    snr_thresh,
+                )
+                continue
+            res[(gain_db, ratio)] = {"mean": mean, "std": std, "snr": snr}
+    logging.info("Collected %d ROI stats (gain-corrected)", len(res))
     return res
 
 

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -46,6 +46,7 @@ from utils.logger import log_memory_usage
 pipeline_lock = threading.Lock()
 from core.analysis import (
     extract_roi_stats,
+    extract_roi_stats_gainmap,
     extract_roi_table,
     calculate_dark_noise,
     calculate_dark_noise_gain,
@@ -112,6 +113,16 @@ def run_pipeline(project: Path, cfg: Dict[str, Any]) -> Dict[str, float]:
             noises = np.array([kv[1]["std"] for kv in tuples])
             snr_lin = signals / noises
             ratios = np.array([kv[0][1] for kv in tuples])
+
+            apply_gain = cfg.get("processing", {}).get("apply_gain_map", False)
+            if apply_gain:
+                stats_corr = extract_roi_stats_gainmap(project, cfg)
+                tuples_c = sorted(stats_corr.items(), key=lambda kv: kv[1]["mean"])
+                signals_corr = np.array([kv[1]["mean"] for kv in tuples_c])
+                noises_corr = np.array([kv[1]["std"] for kv in tuples_c])
+            else:
+                signals_corr = signals
+                noises_corr = noises
 
             roi_table = extract_roi_table(project, cfg)
             flat_roi_file = project / cfg["measurement"].get("flat_roi_file")
@@ -237,7 +248,9 @@ def run_pipeline(project: Path, cfg: Dict[str, Any]) -> Dict[str, float]:
 
             plot_snr_vs_signal_multi(sig_data, cfg, out_dir / "snr_signal.png")
             plot_snr_vs_exposure(exp_data, cfg, out_dir / "snr_exposure.png")
-            plot_prnu_regression(signals, noises, cfg, out_dir / "prnu_fit.png")
+            plot_prnu_regression(
+                signals_corr, noises_corr, cfg, out_dir / "prnu_fit.png"
+            )
             plot_heatmap(dsnu_map, "DSNU map", out_dir / "dsnu_map.png")
             plot_heatmap(rn_map, "Read noise map", out_dir / "readnoise_map.png")
             plot_heatmap(prnu_map, "PRNU residual", out_dir / "prnu_residual_map.png")


### PR DESCRIPTION
## Summary
- add new `extract_roi_stats_gainmap` for gain-corrected ROI statistics
- use gain-corrected stats when plotting PRNU regression
- test the gain-map corrected ROI stats

## Testing
- `black core/analysis.py gui/main_window.py tests/test_analysis.py --quiet`
- `pytest -q`