### PR TITLE
Add ROI area visualization

### DIFF
--- a/core/loader.py
+++ b/core/loader.py
@@ -11,11 +11,13 @@ import numpy as np
 __all__ = [
     "find_condition_folders",
     "load_image_stack",
+    "load_first_frame",
 ]
 
 # -----------------------------------------------------------------------------
 # Helpers
 # -----------------------------------------------------------------------------
+
 
 def _collect_frames(folder: Path) -> List[Path]:
     """Return sorted list of TIFF files (.tif/.tiff) in *folder*."""
@@ -27,14 +29,17 @@ def _collect_frames(folder: Path) -> List[Path]:
 # Public API
 # -----------------------------------------------------------------------------
 
-def find_condition_folders(project_dir: Path | str, cfg: Dict) -> List[Tuple[Path, float, float]]:
+
+def find_condition_folders(
+    project_dir: Path | str, cfg: Dict
+) -> List[Tuple[Path, float, float]]:
     """Discover leaf folders <gain>/<exposure> present on disk.
 
     Returns list[ (folder_path, gain_db, exposure_ratio) ].
     """
     project_dir = Path(project_dir)
 
-    gains_cfg = cfg["measurement"]["gains"]      # dict: db -> {folder: ..}
+    gains_cfg = cfg["measurement"]["gains"]  # dict: db -> {folder: ..}
     exposures_cfg = cfg["measurement"]["exposures"]  # dict: ratio -> {folder: ..}
 
     folders: List[Tuple[Path, float, float]] = []
@@ -59,3 +64,13 @@ def load_image_stack(folder: Path | str) -> np.ndarray:
         raise FileNotFoundError(f"No TIFF files in {folder}")
     stack = [tifffile.imread(str(f)) for f in files]
     return np.stack(stack, axis=0)
+
+
+def load_first_frame(folder: Path | str) -> np.ndarray:
+    """Load the first TIFF frame in *folder* as ``(H,W)`` array."""
+
+    folder = Path(folder)
+    files = _collect_frames(folder)
+    if not files:
+        raise FileNotFoundError(f"No TIFF files in {folder}")
+    return tifffile.imread(str(files[0]))

--- a/core/plotting.py
+++ b/core/plotting.py
@@ -19,6 +19,7 @@ __all__ = [
     "plot_snr_vs_exposure",
     "plot_prnu_regression",
     "plot_heatmap",
+    "plot_roi_area",
 ]
 
 
@@ -185,6 +186,34 @@ def plot_heatmap(data: np.ndarray, title: str, output_path: Path):
     plt.imshow(data, cmap="viridis")
     plt.title(title)
     plt.colorbar(label="DN")
+    plt.tight_layout()
+    plt.savefig(output_path)
+    plt.close()
+
+
+def plot_roi_area(
+    images: Sequence[np.ndarray],
+    rects: Sequence[Sequence[tuple[int, int, int, int]]],
+    titles: Sequence[str],
+    output_path: Path,
+):
+    """Visualize ROI rectangles on given images."""
+
+    if len(images) != len(rects) or len(images) != len(titles):
+        raise ValueError("images, rects and titles must have the same length")
+
+    n = len(images)
+    plt.figure(figsize=(4 * n, 4))
+    for i, (img, rs, title) in enumerate(zip(images, rects, titles), start=1):
+        ax = plt.subplot(1, n, i)
+        ax.imshow(img, cmap="gray")
+        for l, t, w, h in rs:
+            rect = plt.Rectangle(
+                (l, t), w, h, edgecolor="r", facecolor="none", linewidth=1
+            )
+            ax.add_patch(rect)
+        ax.set_title(title)
+        ax.set_axis_off()
     plt.tight_layout()
     plt.savefig(output_path)
     plt.close()

--- a/core/report_gen.py
+++ b/core/report_gen.py
@@ -147,6 +147,7 @@ def report_html(
         "dsnu_map",
         "readnoise_map",
         "prnu_residual_map",
+        "roi_area",
     ]:
         if key in graphs and graphs[key].exists():
             title = key.replace("_", " ").title()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,7 +5,14 @@ import pytest
 
 yaml = pytest.importorskip("yaml")
 
-from utils.config import load_config, gain_entries, gain_ratio, _lookup_nested
+from utils.config import (
+    load_config,
+    gain_entries,
+    gain_ratio,
+    _lookup_nested,
+    nearest_gain,
+    nearest_exposure,
+)
 
 
 def test_load_config_merges_defaults(tmp_path):
@@ -61,3 +68,14 @@ def test_lookup_nested_str_int_key():
     cfg = {"measurement": {"gains": {"0": {"folder": "g0"}}}}
     entries = gain_entries(cfg)
     assert _lookup_nested(cfg["measurement"]["gains"], 0.0)["folder"] == "g0"
+
+
+def test_nearest_gain_exposure():
+    cfg = {
+        "measurement": {
+            "gains": {"0": {"folder": "g0"}, "6": {"folder": "g6"}},
+            "exposures": {"1.0": {"folder": "e1"}, "4.0": {"folder": "e4"}},
+        }
+    }
+    assert nearest_gain(cfg, 2.0) == 0.0
+    assert nearest_exposure(cfg, 2.0) == 1.0

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -39,3 +39,12 @@ def test_plot_snr_vs_signal_multi_invalid(tmp_path):
     data = {0.0: (np.array([1.0]), np.array([-1.0]))}
     with pytest.raises(ValueError):
         plotting.plot_snr_vs_signal_multi(data, {}, tmp_path / "bad.png")
+
+
+def test_plot_roi_area(tmp_path):
+    img = np.zeros((4, 4))
+    rects = [[(0, 0, 2, 2)], [(1, 1, 2, 2)], []]
+    plotting.plot_roi_area(
+        [img, img, img], rects, ["a", "b", "c"], tmp_path / "roi.png"
+    )
+    assert (tmp_path / "roi.png").is_file()

--- a/utils/config.py
+++ b/utils/config.py
@@ -14,6 +14,8 @@ __all__ = [
     "find_gain_folder",
     "find_exposure_folder",
     "gain_ratio",
+    "nearest_gain",
+    "nearest_exposure",
 ]
 
 # ────────────────────────────────────────────────
@@ -110,3 +112,21 @@ def gain_ratio(gain_db: float) -> float:
     """Return linear gain ratio from decibel value."""
 
     return 10 ** (float(gain_db) / 20.0)
+
+
+def nearest_gain(cfg: Dict[str, Any], target: float) -> float:
+    """Return gain value in config closest to ``target``."""
+
+    gains = [g for g, _ in gain_entries(cfg)]
+    if not gains:
+        raise ValueError("No gains defined")
+    return min(gains, key=lambda g: abs(g - float(target)))
+
+
+def nearest_exposure(cfg: Dict[str, Any], target: float) -> float:
+    """Return exposure ratio in config closest to ``target``."""
+
+    ratios = [r for r, _ in exposure_entries(cfg)]
+    if not ratios:
+        raise ValueError("No exposures defined")
+    return min(ratios, key=lambda r: abs(r - float(target)))


### PR DESCRIPTION
## Summary
- visualize ROIs on chart/flat/dark frames
- support nearest gain/exposure lookup
- expose helper to load first frame
- embed roi_area plot in report and GUI
- add unit tests for new features

## Testing
- `black -q .`
- `pytest -q`