### PR TITLE
Update SNR exposure axis to ms

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Run the GUI using `python main.py`
 ##📊 Outputs
 
 	•	📈 snr_signal.png: SNR vs Signal (DN)
-	•	📉 snr_exposure.png: SNR vs Exposure Ratio
+	•	📉 snr_exposure.png: SNR vs Exposure Time
         •       🟢 prnu_fit.png: PRNU regression
         •       🗺 dsnu_map.png: DSNU map
         •       🗺 readnoise_map.png: Read noise map

--- a/config/default_config.yaml
+++ b/config/default_config.yaml
@@ -53,7 +53,7 @@ processing:
 plot:
   # exposures: [4.0,2.0,1.0,0.5,0.25,0.125,0.0625]  # Override order if needed
   color_by_exposure: false         # Optional UI key
-  exposure_labels: [4×,2×,1×,0.5×,0.25×,0.125×,0.0625×]
+  exposure_labels: [3840,1920,960,480,240,120,60]
 
 output:
   output_dir: output

--- a/core/plotting.py
+++ b/core/plotting.py
@@ -113,10 +113,9 @@ def plot_snr_vs_exposure(
             labels = [ratio for ratio, _ in cfgutil.exposure_entries(cfg)]
         except KeyError:
             labels = []
-    label_strs = _auto_labels(labels)
-
     base_ms = float(cfg.get("illumination", {}).get("exposure_ms", 1.0))
     xticks = base_ms * np.array(labels)
+    label_strs = [f"{t:g}" for t in xticks]
 
     thresh = cfg.get("processing", {}).get("snr_threshold_dB", 10.0)
 
@@ -125,8 +124,15 @@ def plot_snr_vs_exposure(
         ratios = _validate_positive_finite(ratios, "exposure ratios")
         snr = _validate_positive_finite(snr, "snr")
         snr_db = 20 * np.log10(snr)
-        times = base_ms * ratios
-        plt.semilogx(times, snr_db, marker="s", linestyle="-", label=f"{gain:g} dB")
+        gain_mult = cfgutil.gain_ratio(gain)
+        times = base_ms * ratios / gain_mult
+        plt.semilogx(
+            times,
+            snr_db,
+            marker="s",
+            linestyle="-",
+            label=f"{gain:g} dB",
+        )
     plt.axhline(thresh, color="r", linestyle="--", label=f"{thresh:g} dB")
     plt.xticks(xticks, label_strs, rotation=45)
     plt.xlabel("Exposure Time (ms)")


### PR DESCRIPTION
## Summary
- plot SNR vs exposure time in milliseconds
- update default exposure labels to ms values
- document graph change in README

## Testing
- `pytest -q`