### PR TITLE
Fix scroll area resizing for graphs

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -510,7 +510,7 @@ class MainWindow(QMainWindow):
         w_container.setLayout(layout)
 
         scroll = QScrollArea()
-        scroll.setWidgetResizable(True)
+        scroll.setWidgetResizable(False)
         scroll.setWidget(w_container)
         return scroll
 


### PR DESCRIPTION
## Summary
- avoid auto-resizing scroll area widgets so scrollbars appear

## Testing
- `pytest -q`