### PR TITLE
Add scaled heatmaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,11 @@ Run the GUI using `python main.py`
 	•	📉 snr_exposure.png: SNR vs Exposure Time
         •       🟢 prnu_fit.png: PRNU regression
         •       🗺 dsnu_map.png: DSNU map
+        •       🗺 dsnu_map_scaled.png: DSNU map (scaled)
         •       🗺 readnoise_map.png: Read noise map
+        •       🗺 readnoise_map_scaled.png: Read noise map (scaled)
         •       🗺 prnu_residual_map.png: PRNU residual map
+        •       🗺 prnu_residual_map_scaled.png: PRNU residual map (scaled)
         •       📋 summary.txt: Key evaluation metrics
         •       📄 report.html: Embedded HTML report
         •       📌 Metrics include SNR @ 50% and DN @ SNR=1 (0 dB)

--- a/Sensor_Output_Spec.md
+++ b/Sensor_Output_Spec.md
@@ -129,17 +129,20 @@ GUI上、および出力画像として出力
 * `dsnu_map.png`：DSNU（遮光画像の画素間オフセット）マップ
   * 表示：ROI領域の空間分布
   * カラーマップ：ヒートマップ（logスケール／標準化あり）
+* `dsnu_map_scaled.png`：DSNUマップ（0〜最大値スケール）
 
 グループ Readnoise MAP
 * `readnoise_map.png`：読み出しノイズの空間分布（Dark画像差分）
   * 表示：ROI内での時間方向標準偏差（各画素ごと）
   * 合成方法：10枚からのstd、または差分法
   * カラーマップ：ヒートマップ
+* `readnoise_map_scaled.png`：読み出しノイズマップ（0〜最大値スケール）
 
 グループ  PRNU Residual
 * `prnu_residual_map.png`：ゲイン補正後の固定パターンノイズ（空間ばらつき）
   * 表示：Flat画像スタックの残差の空間分布（std or RMS）
   * 補正前後で比較可能にしてもよい
+* `prnu_residual_map_scaled.png`：PRNU残差マップ（0〜最大値スケール）
 
 グループ  ROI area
 * `roi_area.png`：画像のROIの可視化

--- a/core/plotting.py
+++ b/core/plotting.py
@@ -204,9 +204,18 @@ def plot_prnu_regression(
     plt.close()
 
 
-def plot_heatmap(data: np.ndarray, title: str, output_path: Path):
+def plot_heatmap(
+    data: np.ndarray,
+    title: str,
+    output_path: Path,
+    *,
+    vmin: float | None = None,
+    vmax: float | None = None,
+) -> None:
+    """Draw heatmap with optional value scaling."""
+
     plt.figure()
-    plt.imshow(data, cmap="viridis")
+    plt.imshow(data, cmap="viridis", vmin=vmin, vmax=vmax)
     plt.title(title)
     plt.colorbar(label="DN")
     plt.tight_layout()

--- a/core/report_gen.py
+++ b/core/report_gen.py
@@ -145,8 +145,11 @@ def report_html(
         "snr_exposure",
         "prnu_fit",
         "dsnu_map",
+        "dsnu_map_scaled",
         "readnoise_map",
+        "readnoise_map_scaled",
         "prnu_residual_map",
+        "prnu_residual_map_scaled",
         "roi_area",
     ]:
         if key in graphs and graphs[key].exists():

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -299,9 +299,30 @@ def run_pipeline(
             logging.info("Plotting noise maps")
             log_memory_usage("before dsnu_map plot: ")
             plot_heatmap(dsnu_map, "DSNU map", out_dir / "dsnu_map.png")
+            plot_heatmap(
+                dsnu_map,
+                "DSNU map (scaled)",
+                out_dir / "dsnu_map_scaled.png",
+                vmin=0,
+                vmax=float(np.nanmax(dsnu_map)),
+            )
             log_memory_usage("after dsnu_map plot: ")
             plot_heatmap(rn_map, "Read noise map", out_dir / "readnoise_map.png")
+            plot_heatmap(
+                rn_map,
+                "Read noise map (scaled)",
+                out_dir / "readnoise_map_scaled.png",
+                vmin=0,
+                vmax=float(np.nanmax(rn_map)),
+            )
             plot_heatmap(prnu_map, "PRNU residual", out_dir / "prnu_residual_map.png")
+            plot_heatmap(
+                prnu_map,
+                "PRNU residual (scaled)",
+                out_dir / "prnu_residual_map_scaled.png",
+                vmin=0,
+                vmax=float(np.nanmax(prnu_map)),
+            )
 
             try:
                 g0 = cfgutil.nearest_gain(cfg, 0.0)
@@ -336,8 +357,11 @@ def run_pipeline(
                 "snr_exposure": out_dir / "snr_exposure.png",
                 "prnu_fit": out_dir / "prnu_fit.png",
                 "dsnu_map": out_dir / "dsnu_map.png",
+                "dsnu_map_scaled": out_dir / "dsnu_map_scaled.png",
                 "readnoise_map": out_dir / "readnoise_map.png",
+                "readnoise_map_scaled": out_dir / "readnoise_map_scaled.png",
                 "prnu_residual_map": out_dir / "prnu_residual_map.png",
+                "prnu_residual_map_scaled": out_dir / "prnu_residual_map_scaled.png",
                 "roi_area": out_dir / "roi_area.png",
             }
             report_html(summary_avg, graphs, cfg, out_dir / "report.html")

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -57,3 +57,15 @@ def test_plot_roi_area(tmp_path):
         [img, img, img], rects, ["a", "b", "c"], tmp_path / "roi.png"
     )
     assert (tmp_path / "roi.png").is_file()
+
+
+def test_plot_heatmap_vmin_vmax(tmp_path):
+    data = np.arange(4).reshape(2, 2)
+    plotting.plot_heatmap(
+        data,
+        "heat",
+        tmp_path / "heat.png",
+        vmin=0.0,
+        vmax=3.0,
+    )
+    assert (tmp_path / "heat.png").is_file()


### PR DESCRIPTION
## Summary
- extend heatmap plotting to support vmin/vmax
- add scaled heatmaps in run_pipeline
- embed scaled heatmap images in report
- test new vmin/vmax feature
- document scaled heatmaps in README and output spec

## Testing
- `black .`
- `pytest -q`
