### PR TITLE
Add gain_map_mode option

### DIFF
--- a/Sensor_Output_Spec.md
+++ b/Sensor_Output_Spec.md
@@ -213,7 +213,8 @@ processing:
   stat_mode: rms              # 'mean', 'rms', 'mad' から選択可能（分散合成・代表値算出に使用）
   snr_threshold_dB: 10       # SNR評価での可視限界（10dB など）
   min_sig_factor: 3           # σ_read の n倍以上を有効信号とみなす
-  apply_gain_map : false      # PRNUの算出時gain_map補正をするか
+  gain_map_mode : none        # self_fit | flat_fit | flat_frame | none
+                             # PRNUの算出時gain_map補正方法
   prnu_fit: LS                # LS:最小二乗法 WLS:加重最小二乗法
   plane_fit_order: 2          # ROI内傾斜補正次数
 

--- a/config/default_config.yaml
+++ b/config/default_config.yaml
@@ -44,7 +44,7 @@ processing:
   snr_threshold_dB: 10             # SNR threshold for DR
   min_sig_factor: 3                # Guard: mean ≥ N×σ
   mask_upper_margin: 0.85          # Use pixels < margin*DN_sat for fitting
-  apply_gain_map: false
+  gain_map_mode: none            # self_fit | flat_fit | flat_frame | none
   plane_fit_order: 2
   read_noise_mode: 0
   prnu_fit: LS

--- a/core/analysis.py
+++ b/core/analysis.py
@@ -177,6 +177,12 @@ def extract_roi_stats_gainmap(
         fitted = np.tensordot(coef, A_full, axes=(0, 0))
         return fitted
 
+    mode = cfg.get("processing", {}).get("gain_map_mode", "none")
+    if mode == "none":
+        return extract_roi_stats(project_dir, cfg)
+
+    flat_cache: Dict[float, np.ndarray] = {}
+
     for gain_db, gfold in cfgutil.gain_entries(cfg):
         for ratio, efold in cfgutil.exposure_entries(cfg):
             folder = project_dir / gfold / efold
@@ -190,9 +196,23 @@ def extract_roi_stats_gainmap(
             if debug_stacks:
                 tifffile.imwrite(folder / "stack_cache.tiff", stack)
 
-            mean_frame = np.mean(stack, axis=0)
             mask_fit = _mask_from_rects(stack.shape[1:], flat_rects)
-            gain_map = _fit_gain(mean_frame, mask_fit, order)
+            if mode == "self_fit":
+                mean_src = np.mean(stack, axis=0)
+                gain_map = _fit_gain(mean_src, mask_fit, order)
+            else:
+                flat_stack = flat_cache.get(gain_db)
+                if flat_stack is None:
+                    flat_folder = cfgutil.find_gain_folder(
+                        project_dir, gain_db, cfg
+                    ) / cfg["measurement"].get("flat_lens_folder", "LensFlat")
+                    flat_stack = load_image_stack(flat_folder)
+                    flat_cache[gain_db] = flat_stack
+                mean_src = np.mean(flat_stack, axis=0)
+                if mode == "flat_fit":
+                    gain_map = _fit_gain(mean_src, mask_fit, order)
+                else:  # flat_frame
+                    gain_map = mean_src
             gain_map = np.where(gain_map == 0, 1e-6, gain_map)
             corrected = stack / gain_map
 
@@ -597,6 +617,8 @@ def calculate_pseudo_prnu(
     flat_stack: np.ndarray,
     cfg: Dict[str, Any],
     rects: list[tuple[int, int, int, int]] | None = None,
+    project_dir: Path | str | None = None,
+    gain_db: float | None = None,
 ) -> Tuple[float, np.ndarray]:
     """Estimate pseudo-PRNU within the specified ROI.
 
@@ -627,7 +649,7 @@ def calculate_pseudo_prnu(
         dn_sat = calculate_dn_sat(flat_stack, cfg)
         mask &= mean_frame <= margin * dn_sat
 
-    apply_gain = cfg.get("processing", {}).get("apply_gain_map", False)
+    mode = cfg.get("processing", {}).get("gain_map_mode", "none")
     order = int(cfg.get("processing", {}).get("plane_fit_order", 0))
 
     def _fit_gain(frame: np.ndarray, mask: np.ndarray, order: int) -> np.ndarray:
@@ -651,8 +673,19 @@ def calculate_pseudo_prnu(
         fitted = np.tensordot(coef, A_full, axes=(0, 0))
         return fitted
 
-    if apply_gain:
-        gain_map = _fit_gain(mean_frame, mask, order)
+    if mode != "none":
+        if mode == "self_fit" or project_dir is None or gain_db is None:
+            mean_src = mean_frame
+        else:
+            flat_folder = cfgutil.find_gain_folder(project_dir, gain_db, cfg) / cfg[
+                "measurement"
+            ].get("flat_lens_folder", "LensFlat")
+            ref_stack = load_image_stack(flat_folder)
+            mean_src = np.mean(ref_stack, axis=0)
+        if mode == "flat_frame":
+            gain_map = mean_src
+        else:
+            gain_map = _fit_gain(mean_src, mask, order)
         gain_map = np.where(gain_map == 0, 1e-6, gain_map)
         corrected = flat_stack / gain_map
         mean_frame = np.mean(corrected, axis=0)
@@ -671,6 +704,8 @@ def calculate_prnu_residual(
     flat_stack: np.ndarray,
     cfg: Dict[str, Any],
     rects: list[tuple[int, int, int, int]] | None = None,
+    project_dir: Path | str | None = None,
+    gain_db: float | None = None,
 ) -> Tuple[float, np.ndarray]:
     """Calculate PRNU residual from a flat-field stack.
 
@@ -701,7 +736,7 @@ def calculate_prnu_residual(
         dn_sat = calculate_dn_sat(flat_stack, cfg)
         mask &= mean_frame <= margin * dn_sat
 
-    apply_gain = cfg.get("processing", {}).get("apply_gain_map", False)
+    mode = cfg.get("processing", {}).get("gain_map_mode", "none")
     order = int(cfg.get("processing", {}).get("plane_fit_order", 0))
 
     def _fit_gain(frame: np.ndarray, mask: np.ndarray, order: int) -> np.ndarray:
@@ -725,8 +760,19 @@ def calculate_prnu_residual(
         fitted = np.tensordot(coef, A_full, axes=(0, 0))
         return fitted
 
-    if apply_gain:
-        gain_map = _fit_gain(mean_frame, mask, order)
+    if mode != "none":
+        if mode == "self_fit" or project_dir is None or gain_db is None:
+            mean_src = mean_frame
+        else:
+            flat_folder = cfgutil.find_gain_folder(project_dir, gain_db, cfg) / cfg[
+                "measurement"
+            ].get("flat_lens_folder", "LensFlat")
+            ref_stack = load_image_stack(flat_folder)
+            mean_src = np.mean(ref_stack, axis=0)
+        if mode == "flat_frame":
+            gain_map = mean_src
+        else:
+            gain_map = _fit_gain(mean_src, mask, order)
         gain_map = np.where(gain_map == 0, 1e-6, gain_map)
         corrected = flat_stack / gain_map
         mean_frame = np.mean(corrected, axis=0)

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -135,8 +135,8 @@ def run_pipeline(
             snr_lin = signals / noises
             ratios = np.array([kv[0][1] for kv in tuples])
 
-            apply_gain = cfg.get("processing", {}).get("apply_gain_map", False)
-            if apply_gain:
+            gain_mode = cfg.get("processing", {}).get("gain_map_mode", "none")
+            if gain_mode != "none":
                 stats_corr = extract_roi_stats_gainmap(project, cfg)
                 tuples_c = sorted(stats_corr.items(), key=lambda kv: kv[1]["mean"])
                 signals_corr = np.array([kv[1]["mean"] for kv in tuples_c])
@@ -189,7 +189,7 @@ def run_pipeline(
                         out_dir / f"flat_cache_{int(gain_db)}dB.tiff", flat_stack
                     )
                 prnu, prnu_map_tmp = calculate_prnu_residual(
-                    flat_stack, cfg, flat_rects
+                    flat_stack, cfg, flat_rects, project, gain_db
                 )
                 gain_mult = cfgutil.gain_ratio(gain_db)
                 sens = calculate_system_sensitivity(

--- a/utils/config.py
+++ b/utils/config.py
@@ -53,6 +53,9 @@ def load_config(project_cfg_path: Path | str) -> Dict[str, Any]:
     if "exposures" in meas:
         meas["exposures"] = {str(k): v for k, v in meas["exposures"].items()}
     cfg["measurement"] = meas
+    proc = cfg.get("processing", {})
+    proc["gain_map_mode"] = str(proc.get("gain_map_mode", "none"))
+    cfg["processing"] = proc
     return cfg
 
 


### PR DESCRIPTION
## Summary
- replace `apply_gain_map` with `gain_map_mode` in config and docs
- keep new option when loading config
- switch GUI to use gain map mode
- extend analysis functions to support gain map modes
- test all gain map modes

## Testing
- `black tests/test_analysis.py core/analysis.py gui/main_window.py utils/config.py`
- `pytest -q`