### PR TITLE
Normalize gain maps to mean 1

### DIFF
--- a/Sensor_Output_Spec.md
+++ b/Sensor_Output_Spec.md
@@ -215,6 +215,7 @@ processing:
   min_sig_factor: 3           # σ_read の n倍以上を有効信号とみなす
   gain_map_mode : none        # self_fit | flat_fit | flat_frame | none
                              # PRNUの算出時gain_map補正方法
+                             # ゲインマップは平均1に正規化して使用する
   prnu_fit: LS                # LS:最小二乗法 WLS:加重最小二乗法
   plane_fit_order: 2          # ROI内傾斜補正次数
 

--- a/core/analysis.py
+++ b/core/analysis.py
@@ -256,6 +256,8 @@ def extract_roi_stats_gainmap(
                 else:  # flat_frame
                     gain_map = mean_src
             gain_map = np.where(gain_map == 0, 1e-6, gain_map)
+            gain_map_mean = np.mean(gain_map[mask_fit])
+            gain_map /= max(gain_map_mean, 1e-6)
             corrected = stack / gain_map
 
             rects = chart_rects if "chart" in efold.lower() else flat_rects
@@ -729,6 +731,8 @@ def calculate_pseudo_prnu(
         else:
             gain_map = _fit_gain(mean_src, mask, order)
         gain_map = np.where(gain_map == 0, 1e-6, gain_map)
+        gain_map_mean = np.mean(gain_map[mask])
+        gain_map /= max(gain_map_mean, 1e-6)
         corrected = flat_stack / gain_map
         mean_frame = np.mean(corrected, axis=0)
         std_frame = np.std(corrected, axis=0)
@@ -816,6 +820,8 @@ def calculate_prnu_residual(
         else:
             gain_map = _fit_gain(mean_src, mask, order)
         gain_map = np.where(gain_map == 0, 1e-6, gain_map)
+        gain_map_mean = np.mean(gain_map[mask])
+        gain_map /= max(gain_map_mean, 1e-6)
         corrected = flat_stack / gain_map
         mean_frame = np.mean(corrected, axis=0)
 

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -300,15 +300,15 @@ def test_extract_roi_stats_gainmap_self_fit(tmp_path):
     cfg = load_config(cfg_file)
     stats = analysis.extract_roi_stats_gainmap(project, cfg)
     res = stats[(0.0, 1.0)]
-    assert pytest.approx(res["mean"], abs=1e-6) == 1.0
-    assert pytest.approx(res["std"], abs=1e-6) == pytest.approx(1.0 / 3.0, abs=1e-6)
+    assert pytest.approx(res["mean"], abs=1e-6) == 22.5
+    assert pytest.approx(res["std"], abs=1e-6) == pytest.approx(7.5, abs=1e-6)
 
 
 @pytest.mark.parametrize(
     "mode, expected_mean, expected_std",
     [
-        ("flat_fit", 11.25, 3.952847075210474),
-        ("flat_frame", 11.25, 3.952847075210474),
+        ("flat_fit", 16.875, 5.929271154968454),
+        ("flat_frame", 16.875, 5.929271154968454),
     ],
 )
 def test_extract_roi_stats_gainmap_modes(tmp_path, mode, expected_mean, expected_std):


### PR DESCRIPTION
## Summary
- normalize gain maps using mean of fitting area
- apply gain map normalization in pseudo PRNU and residual calculations
- document gain map normalization in the spec
- adjust gain map test expectations
- remove comment about normalization from default config

## Testing
- `black --quiet .`
- `pytest -q`
