### PR TITLE
Update gain_map_mode descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ For a comprehensive description of each output file, refer to
 	•	Configurable pipeline via default_config.yaml
 	•	Support for multi-gain and multi-exposure batch evaluation
 	•	PRNU and black-level correction logic
+        •       `gain_map_mode` normalizes the gain map by its mean for relative correction
 	•	Optional Excel/Markdown export
 	•	CI tests (PyTest + GitHub Actions)
 

--- a/Sensor_Output_Spec.md
+++ b/Sensor_Output_Spec.md
@@ -214,7 +214,7 @@ processing:
   snr_threshold_dB: 10       # SNR評価での可視限界（10dB など）
   min_sig_factor: 3           # σ_read の n倍以上を有効信号とみなす
   gain_map_mode : none        # self_fit | flat_fit | flat_frame | none
-                             # PRNUの算出時gain_map補正方法
+                             # ゲインマップは平均値で正規化して相対補正を行う
   prnu_fit: LS                # LS:最小二乗法 WLS:加重最小二乗法
   plane_fit_order: 2          # ROI内傾斜補正次数
 

--- a/config/default_config.yaml
+++ b/config/default_config.yaml
@@ -44,7 +44,7 @@ processing:
   snr_threshold_dB: 10             # SNR threshold for DR
   min_sig_factor: 3                # Guard: mean ≥ N×σ
   mask_upper_margin: 0.85          # Use pixels < margin*DN_sat for fitting
-  gain_map_mode: none            # self_fit | flat_fit | flat_frame | none
+  gain_map_mode: none            # ゲインマップは平均値で正規化して相対補正を行う
   plane_fit_order: 2
   read_noise_mode: 0
   prnu_fit: LS


### PR DESCRIPTION
## Summary
- clarify how gain_map_mode works in default config and spec
- document gain_map_mode in README

## Testing
- `black . --quiet`
- `pytest -q`
