### PR TITLE
Fix summary display in HTML report

### DIFF
--- a/core/report_gen.py
+++ b/core/report_gen.py
@@ -126,20 +126,26 @@ def report_html(
         ],
     )
 
-    rows = "".join(
-        (
-            f"<tr><td>{k}</td><td>{summary.get(k, '—'):.3f}</td></tr>"
-            if isinstance(summary.get(k), (int, float))
-            else f"<tr><td>{k}</td><td>{summary.get(k, '—')}</td></tr>"
-        )
-        for k in order
-    )
+    summary_file = path.parent / "summary.txt"
+    if summary_file.is_file():
+        summary_text = summary_file.read_text(encoding="utf-8")
+    else:
+        lines = _meta_lines(cfg)
+        for k in order:
+            val = summary.get(k, "—")
+            if isinstance(val, (int, float)):
+                lines.append(f"{k}: {val:.3f}")
+            else:
+                lines.append(f"{k}: {val}")
+        summary_text = "\n".join(lines)
 
     html = [
         "<html><head><meta charset='utf-8'><title>Sensor Evaluation Report</title></head><body>"
     ]
     html.append("<h1>Sensor Evaluation Summary</h1>")
-    html.append(f"<table border='1' cellpadding='4'>{rows}</table>")
+    html.append("<pre>")
+    html.append(summary_text)
+    html.append("</pre>")
     groups = [
         ("snr_signal",),
         ("snr_exposure",),

--- a/tests/test_report_gen.py
+++ b/tests/test_report_gen.py
@@ -3,7 +3,7 @@ import pytest
 yaml = pytest.importorskip("yaml")
 
 from utils.config import load_config
-from core.report_gen import save_summary_txt
+from core.report_gen import save_summary_txt, report_html
 
 
 def test_save_summary_txt_full_scale(tmp_path):
@@ -23,3 +23,20 @@ def test_save_summary_txt_full_scale(tmp_path):
     text = out_file.read_text(encoding="utf-8")
     assert "ADC Full Scale (DN):" in text
     assert str(((1 << 10) - 1) * (1 << 6)) in text
+
+
+def test_report_html_summary_text(tmp_path):
+    cfg_data = {"output": {"report_html": True}}
+    cfg_file = tmp_path / "config.yaml"
+    with cfg_file.open("w", encoding="utf-8") as fh:
+        yaml.safe_dump(cfg_data, fh)
+    cfg = load_config(cfg_file)
+
+    summary_path = tmp_path / "summary.txt"
+    summary_text = "Line1\nLine2"
+    summary_path.write_text(summary_text, encoding="utf-8")
+
+    html_file = tmp_path / "report.html"
+    report_html({}, {}, cfg, html_file)
+    html = html_file.read_text(encoding="utf-8")
+    assert "Line1" in html and "Line2" in html


### PR DESCRIPTION
## Summary
- embed `summary.txt` text directly into HTML reports
- test that `report_html` includes summary text

## Testing
- `pytest -q`