### PR TITLE
Add black level metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Run the GUI using `python main.py`
         •       🗺 prnu_residual_map_scaled.png: PRNU residual map (scaled to 99th percentile)
         •       📋 summary.txt: Key evaluation metrics
         •       📄 report.html: Embedded HTML report
-        •       📌 Metrics include SNR @ 50% and DN @ SNR=1 (0 dB)
+        •       📌 Metrics include SNR @ 50%, DN @ SNR=1 (0 dB), and Black level (DN)
         •       📑 roi_stats.csv: Per-condition stats
 
 For a comprehensive description of each output file, refer to

--- a/Sensor_Output_Spec.md
+++ b/Sensor_Output_Spec.md
@@ -56,6 +56,7 @@ Gainごとに下記項目を出力
     ※ 平均フレームから ROI 平均を引いた残差の空間ばらつきを DSNU と同様の方法で統計化する。ただし PRNU は出力を ROI 平均信号値で正規化する（残差/μ × 100 \[%]）。
 * **DSNU (DN)**：遮光画像10枚を平均 → 各画素値の空間方向標準偏差（ROI内）を計算し、config.processing.stat\_mode に従って代表値を算出。
 * **Read Noise (DN)**：遮光画像10枚の時間方向標準偏差（各画素の時系列におけるstd）を計算し、空間方向にまとめる際に config.processing.stat\_mode に従って代表値（rms/mean/mad）を算出。
+* **Black level (DN)**：ダーク画像スタックから ROI 平均値を求めたもの。ダーク補正に使用するスカラ値。
 
   * 使用モード：config.processing.read\_noise\_mode
     * 0：スタック全体の標準偏差から計算（デフォルト）
@@ -245,6 +246,7 @@ output:
     - DN @ 10 dB
     - DN @ 0 dB
     - Read Noise (DN)
+    - Black level (DN)
     - DSNU (DN)
     - DN_sat
     - PRNU (%)

--- a/config/default_config.yaml
+++ b/config/default_config.yaml
@@ -69,6 +69,7 @@ output:
     - DN @ 10 dB
     - DN @ 0 dB
     - Read Noise (DN)
+    - Black level (DN)
     - DSNU (DN)
     - DN_sat
     - PRNU (%)

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -62,12 +62,15 @@ def test_calculate_dark_noise_gain(tmp_path):
 
     cfg = load_config(cfg_file)
 
-    dsnu, rn, dsnu_map, rn_map = analysis.calculate_dark_noise_gain(project, 0, cfg)
+    dsnu, rn, dsnu_map, rn_map, black = analysis.calculate_dark_noise_gain(
+        project, 0, cfg
+    )
 
     assert pytest.approx(dsnu, abs=1e-6) == 0.0
     assert pytest.approx(rn, abs=1e-6) == 0.5
     assert dsnu_map.shape == (2, 2)
     assert rn_map.shape == (2, 2)
+    assert pytest.approx(black, abs=1e-6) == 0.5
 
 
 def test_calculate_system_sensitivity_ratio():


### PR DESCRIPTION
## Summary
- compute black level from dark images
- include it in summary output and docs
- update default report order and tests

## Testing
- `black core/analysis.py gui/main_window.py tests/test_analysis.py`
- `pytest -q`