### PR TITLE
Add gain map display for PRNU residual group

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Run the GUI using `python main.py`
         •       🗺 readnoise_map_scaled.png: Read noise map (scaled to 99th percentile)
         •       🗺 prnu_residual_map.png: PRNU residual map (mean frame minus ROI average)
         •       🗺 prnu_residual_map_scaled.png: PRNU residual map (scaled to 99th percentile)
+        •       🗺 gain_map.png: Gain map (normalized to brightest pixel)
         •       📋 summary.txt: Key evaluation metrics
         •       📄 report.html: Embedded HTML report
         •       📌 Metrics include SNR @ 50%, DN @ SNR=1 (0 dB), and Black level (DN)

--- a/Sensor_Output_Spec.md
+++ b/Sensor_Output_Spec.md
@@ -150,6 +150,7 @@ GUI上、および出力画像として出力
   * 表示：Flat画像スタックの残差の空間分布（std or RMS）
   * 補正前後で比較可能にしてもよい
 * `prnu_residual_map_scaled.png`：PRNU残差マップ（0〜99パーセンタイルスケール）
+* `gain_map.png`：ゲインマップ（最大値で正規化）
 
 グループ  ROI area
 * `roi_area.png`：画像のROIの可視化

--- a/core/analysis.py
+++ b/core/analysis.py
@@ -36,6 +36,7 @@ __all__ = [
     "calculate_dn_at_snr_one",
     "fit_gain_map",
     "get_gain_map",
+    "calculate_gain_map",
     "calculate_pseudo_prnu",
     "calculate_prnu_residual",
 ]
@@ -60,9 +61,7 @@ def _load_stack_cached(folder: Path) -> np.ndarray:
 # ───────────────────────────── internal helpers
 
 
-def _mask_from_rects(
-    shape: Tuple[int, int], rects: List[Tuple[int, int, int, int]]
-) -> np.ndarray:
+def _mask_from_rects(shape: Tuple[int, int], rects: List[Tuple[int, int, int, int]]) -> np.ndarray:
     mask = np.zeros(shape, bool)
     for l, t, w, h in rects:
         mask[t : t + h, l : l + w] = True
@@ -185,9 +184,9 @@ def get_gain_map(
         )
     else:
         if stack is None:
-            flat_folder = cfgutil.find_gain_folder(project_dir, gain_db, cfg) / cfg[
-                "measurement"
-            ].get("flat_lens_folder", "LensFlat")
+            flat_folder = cfgutil.find_gain_folder(project_dir, gain_db, cfg) / cfg["measurement"].get(
+                "flat_lens_folder", "LensFlat"
+            )
             stack = load_image_stack(flat_folder)
             mean_src = np.mean(stack, axis=0)
             logging.debug(
@@ -266,9 +265,7 @@ def extract_roi_stats(
     chart_rects = load_rois(chart_roi_file)
     flat_rects = load_rois(flat_roi_file)
 
-    mid_idx = cfg.get("reference", {}).get(
-        "roi_mid_index", cfg.get("measurement", {}).get("roi_mid_index", 5)
-    )
+    mid_idx = cfg.get("reference", {}).get("roi_mid_index", cfg.get("measurement", {}).get("roi_mid_index", 5))
 
     snr_thresh = cfg["processing"].get("snr_threshold_dB", 10.0)
     min_sig_factor = cfg["processing"].get("min_sig_factor", 3.0)
@@ -285,9 +282,7 @@ def extract_roi_stats(
             if not folder.is_dir():
                 logging.info("Skipping missing folder: %s", folder)
                 continue
-            logging.info(
-                "Processing folder %s (%.1f dB, %.3fx)", folder, gain_db, ratio
-            )
+            logging.info("Processing folder %s (%.1f dB, %.3fx)", folder, gain_db, ratio)
             if status:
                 status(f"Loading images for gain {gain_db:.1f} dB")
             stack = _load_stack_cached(folder)
@@ -301,9 +296,9 @@ def extract_roi_stats(
                 if mode != "self_fit":
                     flat_stack = flat_cache.get(gain_db)
                     if flat_stack is None:
-                        flat_folder = cfgutil.find_gain_folder(
-                            project_dir, gain_db, cfg
-                        ) / cfg["measurement"].get("flat_lens_folder", "LensFlat")
+                        flat_folder = cfgutil.find_gain_folder(project_dir, gain_db, cfg) / cfg["measurement"].get(
+                            "flat_lens_folder", "LensFlat"
+                        )
                         if status:
                             status(f"Loading flat frames for gain {gain_db:.1f} dB")
                         flat_stack = _load_stack_cached(flat_folder)
@@ -378,9 +373,7 @@ def extract_roi_stats_gainmap(
     )
 
 
-def extract_roi_table(
-    project_dir: Path | str, cfg: Dict[str, Any]
-) -> List[Dict[str, Any]]:
+def extract_roi_table(project_dir: Path | str, cfg: Dict[str, Any]) -> List[Dict[str, Any]]:
     """Return ROI statistics formatted for CSV output.
 
     Parameters
@@ -441,9 +434,7 @@ def extract_roi_table(
     return rows
 
 
-def collect_mid_roi_snr(
-    rows: List[Dict[str, Any]], mid_index: int
-) -> Dict[float, tuple[np.ndarray, np.ndarray]]:
+def collect_mid_roi_snr(rows: List[Dict[str, Any]], mid_index: int) -> Dict[float, tuple[np.ndarray, np.ndarray]]:
     """Return SNR curves for the grayscale ROI at ``mid_index``.
 
     Parameters
@@ -543,9 +534,7 @@ def collect_prnu_points(
     return res
 
 
-def calculate_snr_curve(
-    signal: np.ndarray, noise: np.ndarray, cfg: Dict[str, Any]
-) -> np.ndarray:
+def calculate_snr_curve(signal: np.ndarray, noise: np.ndarray, cfg: Dict[str, Any]) -> np.ndarray:
     """Compute the signal-to-noise ratio for each pixel.
 
     Parameters
@@ -565,9 +554,7 @@ def calculate_snr_curve(
     return snr
 
 
-def calculate_dynamic_range(
-    snr: np.ndarray, signal: np.ndarray, cfg: Dict[str, Any]
-) -> float:
+def calculate_dynamic_range(snr: np.ndarray, signal: np.ndarray, cfg: Dict[str, Any]) -> float:
     """Estimate dynamic range from the SNR curve.
 
     Parameters
@@ -609,9 +596,7 @@ def _reduce(values: np.ndarray, mode: str) -> float:
     raise ValueError(mode)
 
 
-def calculate_dark_noise(
-    project_dir: Path | str, cfg: Dict[str, Any]
-) -> Tuple[float, float]:
+def calculate_dark_noise(project_dir: Path | str, cfg: Dict[str, Any]) -> Tuple[float, float]:
     """Calculate DSNU and read noise from a dark frame stack.
 
     Parameters
@@ -771,11 +756,7 @@ def calculate_pseudo_prnu(
         ``(pseudo_prnu_percent, residual_map)`` where the residual map matches the image shape.
     """
 
-    mask = (
-        _mask_from_rects(flat_stack.shape[1:], rects)
-        if rects
-        else np.ones(flat_stack.shape[1:], bool)
-    )
+    mask = _mask_from_rects(flat_stack.shape[1:], rects) if rects else np.ones(flat_stack.shape[1:], bool)
 
     mean_frame = np.mean(flat_stack, axis=0)
     margin = cfg.get("processing", {}).get("mask_upper_margin")
@@ -797,11 +778,7 @@ def calculate_pseudo_prnu(
         mask,
         project_dir=project_dir,
         gain_db=gain_db,
-        stack=(
-            flat_stack
-            if mode == "self_fit" or project_dir is None or gain_db is None
-            else None
-        ),
+        stack=(flat_stack if mode == "self_fit" or project_dir is None or gain_db is None else None),
     )
 
     if gain_map is not None:
@@ -812,10 +789,27 @@ def calculate_pseudo_prnu(
         std_frame = np.std(flat_stack, axis=0)
 
     stat_mode = cfg.get("processing", {}).get("stat_mode", "rms")
-    value = (
-        _reduce(std_frame[mask], stat_mode) / max(mean_frame[mask].mean(), 1e-6) * 100.0
-    )
+    value = _reduce(std_frame[mask], stat_mode) / max(mean_frame[mask].mean(), 1e-6) * 100.0
     return value, std_frame
+
+
+def calculate_gain_map(
+    flat_stack: np.ndarray,
+    cfg: Dict[str, Any],
+    rects: list[tuple[int, int, int, int]] | None = None,
+    project_dir: Path | str | None = None,
+    gain_db: float | None = None,
+) -> np.ndarray | None:
+    """Return gain map using flat-field stack and configuration."""
+
+    mask = _mask_from_rects(flat_stack.shape[1:], rects) if rects else np.ones(flat_stack.shape[1:], bool)
+    return get_gain_map(
+        cfg,
+        mask,
+        project_dir=project_dir,
+        gain_db=gain_db,
+        stack=flat_stack,
+    )
 
 
 def calculate_prnu_residual(
@@ -842,11 +836,7 @@ def calculate_prnu_residual(
         ``(prnu_percent, residual_map)`` where the residual map matches the image size.
     """
 
-    mask = (
-        _mask_from_rects(flat_stack.shape[1:], rects)
-        if rects
-        else np.ones(flat_stack.shape[1:], bool)
-    )
+    mask = _mask_from_rects(flat_stack.shape[1:], rects) if rects else np.ones(flat_stack.shape[1:], bool)
 
     mean_frame = np.mean(flat_stack, axis=0)
     margin = cfg.get("processing", {}).get("mask_upper_margin")
@@ -861,11 +851,7 @@ def calculate_prnu_residual(
         mask,
         project_dir=project_dir,
         gain_db=gain_db,
-        stack=(
-            flat_stack
-            if mode == "self_fit" or project_dir is None or gain_db is None
-            else None
-        ),
+        stack=(flat_stack if mode == "self_fit" or project_dir is None or gain_db is None else None),
     )
 
     if gain_map is not None:
@@ -919,11 +905,7 @@ def calculate_system_sensitivity(
         Sensitivity in DN / (µW·cm⁻²·s). Returns ``0.0`` if the denominator is zero.
     """
 
-    mask = (
-        _mask_from_rects(flat_stack.shape[1:], rects)
-        if rects
-        else np.ones(flat_stack.shape[1:], bool)
-    )
+    mask = _mask_from_rects(flat_stack.shape[1:], rects) if rects else np.ones(flat_stack.shape[1:], bool)
 
     illum = cfg.get("illumination", {})
     power = float(illum.get("power_uW_cm2", 1.0))
@@ -936,9 +918,7 @@ def calculate_system_sensitivity(
     return mean_dn / denom
 
 
-def calculate_dn_at_snr(
-    signal: np.ndarray, snr_lin: np.ndarray, threshold_db: float
-) -> float:
+def calculate_dn_at_snr(signal: np.ndarray, snr_lin: np.ndarray, threshold_db: float) -> float:
     """Interpolate the DN value where the SNR reaches ``threshold_db``.
 
     Parameters
@@ -969,9 +949,7 @@ def calculate_dn_at_snr(
     return float(x0 + r * (x1 - x0))
 
 
-def calculate_snr_at_half(
-    signal: np.ndarray, snr_lin: np.ndarray, dn_sat: float
-) -> float:
+def calculate_snr_at_half(signal: np.ndarray, snr_lin: np.ndarray, dn_sat: float) -> float:
     """Return the SNR in dB at half of ``dn_sat``.
 
     Parameters

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -61,6 +61,7 @@ from core.analysis import (
     calculate_snr_at_half,
     calculate_dn_at_snr_one,
     calculate_prnu_residual,
+    calculate_gain_map,
 )
 from core.plotting import (
     plot_snr_vs_signal_multi,
@@ -168,33 +169,29 @@ def run_pipeline(
             gains_list = [g for g, _ in cfgutil.gain_entries(cfg)]
             step = 60 / len(gains_list) if gains_list else 60
             first = True
+            gain_map = None
             for idx, (gain_db, _) in enumerate(cfgutil.gain_entries(cfg)):
                 if status:
                     status(f"Processing gain {gain_db:.1f} dB")
                 logging.info("Processing gain %.1f dB", gain_db)
-                dsnu, rn, dsnu_map_tmp, rn_map_tmp, black_level = (
-                    calculate_dark_noise_gain(project, gain_db, cfg, status=status)
+                dsnu, rn, dsnu_map_tmp, rn_map_tmp, black_level = calculate_dark_noise_gain(
+                    project, gain_db, cfg, status=status
                 )
-                flat_folder = cfgutil.find_gain_folder(project, gain_db, cfg) / cfg[
-                    "measurement"
-                ].get("flat_lens_folder", "flat")
+                flat_folder = cfgutil.find_gain_folder(project, gain_db, cfg) / cfg["measurement"].get(
+                    "flat_lens_folder", "flat"
+                )
                 if status:
                     status(f"Loading flat frames for gain {gain_db:.1f} dB")
                 flat_stack = load_image_stack(flat_folder)
+                gain_map_tmp = calculate_gain_map(flat_stack, cfg, flat_rects, project, gain_db)
                 if debug_stacks and first:
-                    dark_folder = cfgutil.find_gain_folder(project, gain_db, cfg) / cfg[
-                        "measurement"
-                    ].get("dark_folder", "dark")
+                    dark_folder = cfgutil.find_gain_folder(project, gain_db, cfg) / cfg["measurement"].get(
+                        "dark_folder", "dark"
+                    )
                     dark_stack = load_image_stack(dark_folder)
-                    tifffile.imwrite(
-                        out_dir / f"dark_cache_{int(gain_db)}dB.tiff", dark_stack
-                    )
-                    tifffile.imwrite(
-                        out_dir / f"flat_cache_{int(gain_db)}dB.tiff", flat_stack
-                    )
-                prnu, prnu_map_tmp = calculate_prnu_residual(
-                    flat_stack, cfg, flat_rects, project, gain_db
-                )
+                    tifffile.imwrite(out_dir / f"dark_cache_{int(gain_db)}dB.tiff", dark_stack)
+                    tifffile.imwrite(out_dir / f"flat_cache_{int(gain_db)}dB.tiff", flat_stack)
+                prnu, prnu_map_tmp = calculate_prnu_residual(flat_stack, cfg, flat_rects, project, gain_db)
                 gain_mult = cfgutil.gain_ratio(gain_db)
                 sens = calculate_system_sensitivity(
                     flat_stack,
@@ -203,7 +200,12 @@ def run_pipeline(
                     ratio=1.0 / gain_mult,
                 )
                 if first:
-                    dsnu_map, rn_map, prnu_map = dsnu_map_tmp, rn_map_tmp, prnu_map_tmp
+                    dsnu_map, rn_map, prnu_map, gain_map = (
+                        dsnu_map_tmp,
+                        rn_map_tmp,
+                        prnu_map_tmp,
+                        gain_map_tmp,
+                    )
                     dn_sat = calculate_dn_sat(flat_stack, cfg)
                     first = False
 
@@ -257,9 +259,7 @@ def run_pipeline(
             prnu = float(np.mean(prnu_list)) if prnu_list else float("nan")
             system_sens = float(np.mean(sens_list)) if sens_list else float("nan")
             black_level = float(np.mean(black_list)) if black_list else 0.0
-            dn_at_10 = calculate_dn_at_snr(
-                signals, snr_lin, cfg["processing"].get("snr_threshold_dB", 10.0)
-            )
+            dn_at_10 = calculate_dn_at_snr(signals, snr_lin, cfg["processing"].get("snr_threshold_dB", 10.0))
             snr_at_50 = calculate_snr_at_half(signals, snr_lin, dn_sat)
             dn_at_0 = calculate_dn_at_snr_one(signals, snr_lin)
 
@@ -285,38 +285,28 @@ def run_pipeline(
             }
             save_summary_txt(per_gain, cfg, out_dir / "summary.txt")
 
-            mid_idx = cfg.get("reference", {}).get(
-                "roi_mid_index", cfg.get("measurement", {}).get("roi_mid_index", 5)
-            )
+            mid_idx = cfg.get("reference", {}).get("roi_mid_index", cfg.get("measurement", {}).get("roi_mid_index", 5))
             exp_data = collect_mid_roi_snr(roi_table, mid_idx)
             sig_data = collect_gain_snr_signal(roi_table, cfg)
 
             logging.info("Plotting SNR vs Signal (multi)")
             log_memory_usage("before snr_signal plot: ")
-            fig_snr_signal = plot_snr_vs_signal_multi(
-                sig_data, cfg, out_dir / "snr_signal.png", return_fig=True
-            )
+            fig_snr_signal = plot_snr_vs_signal_multi(sig_data, cfg, out_dir / "snr_signal.png", return_fig=True)
             log_memory_usage("after snr_signal plot: ")
 
             logging.info("Plotting SNR vs Exposure")
             log_memory_usage("before snr_exposure plot: ")
-            fig_snr_exposure = plot_snr_vs_exposure(
-                exp_data, cfg, out_dir / "snr_exposure.png", return_fig=True
-            )
+            fig_snr_exposure = plot_snr_vs_exposure(exp_data, cfg, out_dir / "snr_exposure.png", return_fig=True)
             log_memory_usage("after snr_exposure plot: ")
 
             logging.info("Plotting PRNU regression")
             log_memory_usage("before prnu_fit plot: ")
-            fig_prnu_fit = plot_prnu_regression(
-                prnu_data, cfg, out_dir / "prnu_fit.png", return_fig=True
-            )
+            fig_prnu_fit = plot_prnu_regression(prnu_data, cfg, out_dir / "prnu_fit.png", return_fig=True)
             log_memory_usage("after prnu_fit plot: ")
 
             logging.info("Plotting noise maps")
             log_memory_usage("before dsnu_map plot: ")
-            fig_dsnu_map = plot_heatmap(
-                dsnu_map, "DSNU map", out_dir / "dsnu_map.png", return_fig=True
-            )
+            fig_dsnu_map = plot_heatmap(dsnu_map, "DSNU map", out_dir / "dsnu_map.png", return_fig=True)
             fig_dsnu_map_scaled = plot_heatmap(
                 dsnu_map,
                 "DSNU map (scaled)",
@@ -326,9 +316,7 @@ def run_pipeline(
                 return_fig=True,
             )
             log_memory_usage("after dsnu_map plot: ")
-            fig_rn_map = plot_heatmap(
-                rn_map, "Read noise map", out_dir / "readnoise_map.png", return_fig=True
-            )
+            fig_rn_map = plot_heatmap(rn_map, "Read noise map", out_dir / "readnoise_map.png", return_fig=True)
             fig_rn_map_scaled = plot_heatmap(
                 rn_map,
                 "Read noise map (scaled)",
@@ -352,19 +340,26 @@ def run_pipeline(
                 return_fig=True,
             )
 
+            fig_gain_map = None
+            if gain_map is not None:
+                fig_gain_map = plot_heatmap(
+                    gain_map,
+                    "Gain map",
+                    out_dir / "gain_map.png",
+                    return_fig=True,
+                )
+
             fig_roi_area = None
             try:
                 g0 = cfgutil.nearest_gain(cfg, 0.0)
                 r1 = cfgutil.nearest_exposure(cfg, 1.0)
                 chart_folder = cfgutil.find_exposure_folder(project, g0, r1, cfg)
                 chart_img = load_first_frame(chart_folder)
-                flat_folder = cfgutil.find_gain_folder(project, g0, cfg) / cfg[
-                    "measurement"
-                ].get("flat_lens_folder", "LensFlat")
+                flat_folder = cfgutil.find_gain_folder(project, g0, cfg) / cfg["measurement"].get(
+                    "flat_lens_folder", "LensFlat"
+                )
                 flat_img = load_first_frame(flat_folder)
-                dark_folder = cfgutil.find_gain_folder(project, g0, cfg) / cfg[
-                    "measurement"
-                ].get("dark_folder", "dark")
+                dark_folder = cfgutil.find_gain_folder(project, g0, cfg) / cfg["measurement"].get("dark_folder", "dark")
                 dark_img = load_first_frame(dark_folder)
                 chart_rects = load_rois(project / cfg["measurement"]["chart_roi_file"])
                 flat_rects = load_rois(project / cfg["measurement"]["flat_roi_file"])
@@ -392,6 +387,7 @@ def run_pipeline(
                 "readnoise_map_scaled": out_dir / "readnoise_map_scaled.png",
                 "prnu_residual_map": out_dir / "prnu_residual_map.png",
                 "prnu_residual_map_scaled": out_dir / "prnu_residual_map_scaled.png",
+                "gain_map": out_dir / "gain_map.png",
                 "roi_area": out_dir / "roi_area.png",
             }
             figures = {
@@ -405,6 +401,8 @@ def run_pipeline(
                 "prnu_residual_map": fig_prnu_map,
                 "prnu_residual_map_scaled": fig_prnu_map_scaled,
             }
+            if fig_gain_map is not None:
+                figures["gain_map"] = fig_gain_map
             if fig_roi_area is not None:
                 figures["roi_area"] = fig_roi_area
             report_html(summary_avg, graphs, cfg, out_dir / "report.html")
@@ -481,9 +479,7 @@ class MainWindow(QMainWindow):
         self.project_dir = path
         cfg_path = self.project_dir / "config.yaml"
         if not cfg_path.is_file():
-            QMessageBox.critical(
-                self, "Error", "config.yaml not found in project folder"
-            )
+            QMessageBox.critical(self, "Error", "config.yaml not found in project folder")
             return
         self.config = load_config(cfg_path)
         self.status.setText(f"Project loaded: {self.project_dir}")
@@ -496,9 +492,7 @@ class MainWindow(QMainWindow):
             return
         cfg_path = self.project_dir / "config.yaml"
         if not cfg_path.is_file():
-            QMessageBox.critical(
-                self, "Error", "config.yaml not found in project folder"
-            )
+            QMessageBox.critical(self, "Error", "config.yaml not found in project folder")
             return
         # reload configuration fresh each run to avoid stale values
         self.config = load_config(cfg_path)
@@ -529,9 +523,7 @@ class MainWindow(QMainWindow):
         if self.project_dir is None or self.config is None:
             return
 
-        out_dir = self.project_dir / self.config.get("output", {}).get(
-            "output_dir", "output"
-        )
+        out_dir = self.project_dir / self.config.get("output", {}).get("output_dir", "output")
 
         summary = result.get("summary", {})
         figures = result.get("figures", {})
@@ -551,7 +543,11 @@ class MainWindow(QMainWindow):
             "PRNU Fit": ["prnu_fit"],
             "DSNU Map": ["dsnu_map", "dsnu_map_scaled"],
             "Readnoise Map": ["readnoise_map", "readnoise_map_scaled"],
-            "PRNU Residual": ["prnu_residual_map", "prnu_residual_map_scaled"],
+            "PRNU Residual": [
+                "prnu_residual_map",
+                "prnu_residual_map_scaled",
+                "gain_map",
+            ],
             "ROI Area": ["roi_area"],
         }
 


### PR DESCRIPTION
## Summary
- compute gain map via new `calculate_gain_map`
- show gain map image under PRNU Residual graphs in GUI
- document gain map output in README and Sensor_Output_Spec

## Testing
- `black gui/main_window.py core/analysis.py --line-length 120`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6839d8c881308333b84410e743a0d859