### PR TITLE
Implement lower margin mask for gain map fit

### DIFF
--- a/Sensor_Output_Spec.md
+++ b/Sensor_Output_Spec.md
@@ -222,6 +222,7 @@ processing:
   snr_threshold_dB: 10       # SNR評価での可視限界（10dB など）
   min_sig_factor: 3           # σ_read の n倍以上を有効信号とみなす
   mask_upper_margin: 0.85     # 飽和 DN_sat の 90 % 未満を回帰に使う
+  mask_lower_margin: 0.0      # 飽和 DN_sat の一定割合以上を回帰に使う
   gain_map_mode : none        # self_fit | flat_fit | flat_frame | none  PRNUの算出時gain_map補正方法
   plane_fit_order: 2          # ROI内傾斜補正次数
   read_noise_mode: 0          # 0:スタックstd, 1:差分std/√2

--- a/config/default_config.yaml
+++ b/config/default_config.yaml
@@ -44,6 +44,7 @@ processing:
   snr_threshold_dB: 10             # SNR threshold for DR
   min_sig_factor: 3                # Guard: mean ≥ N×σ
   mask_upper_margin: 0.85          # Use pixels < margin*DN_sat for fitting
+  mask_lower_margin: 0.0           # Use pixels >= margin*DN_sat for fitting
   gain_map_mode: none              # self_fit | flat_fit | flat_frame | none
                                   # gain map is scaled by its maximum
   plane_fit_order: 2               # Polynomial order for plane fitting


### PR DESCRIPTION
## Summary
- add `mask_lower_margin` config option
- compute gain-map fit mask using lower and upper margins
- ignore ROI when constructing gain-map mask

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6839ff9dcc308333b9c8f5c68d85ad51