### PR TITLE
Add RBF gain fit option

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ For a comprehensive description of each output file, refer to
 	•	Support for multi-gain and multi-exposure batch evaluation
 	•	PRNU and black-level correction logic
         •       `gain_map_mode` normalizes the gain map by its maximum for relative correction
+        •       `gain_fit_method` chooses polynomial (`poly`) or radial basis (`rbf`) fitting
 	•	Optional Excel/Markdown export
 	•	CI tests (PyTest + GitHub Actions)
 

--- a/Sensor_Output_Spec.md
+++ b/Sensor_Output_Spec.md
@@ -51,6 +51,7 @@ Gainごとに下記項目を出力
     * flat_fitはそのGainのフラット画像スタック平均値を平面フィットさせてマップを作成
     * flat_frameはそのGainのフラット画像スタックの平均値を正規化してマップを作成
     * noneはゲインマップ補正なし
+  * フィット手法選択: gain_fit_method (poly|rbf)。rbfは計算時間が長くなるため注意
   * フィッティング法：config.processing.prnu\_fit（"LS" or "WLS"）※ μ-σ回帰を行う場合に適用
   * 使用回帰：config.processing.prnu\_fit（"LS" or "WLS"）
     ※ 平均フレームから ROI 平均を引いた残差の空間ばらつきを DSNU と同様の方法で統計化する。ただし PRNU は出力を ROI 平均信号値で正規化する（残差/μ × 100 \[%]）。
@@ -225,6 +226,7 @@ processing:
   mask_lower_margin: 0.0      # 飽和 DN_sat の一定割合以上を回帰に使う
   gain_map_mode : none        # self_fit | flat_fit | flat_frame | none  PRNUの算出時gain_map補正方法
   plane_fit_order: 2          # ROI内傾斜補正次数
+  gain_fit_method: poly       # poly | rbf  フィッティング手法
   read_noise_mode: 0          # 0:スタックstd, 1:差分std/√2
   prnu_fit: LS                # LS:最小二乗法 WLS:加重最小二乗法
   exclude_abnormal_snr: true  # SNRが極端に低いROIを除外

--- a/config/default_config.yaml
+++ b/config/default_config.yaml
@@ -48,6 +48,7 @@ processing:
   gain_map_mode: none              # self_fit | flat_fit | flat_frame | none
                                   # gain map is scaled by its maximum
   plane_fit_order: 2               # Polynomial order for plane fitting
+  gain_fit_method: poly            # poly | rbf
   read_noise_mode: 0               # 0: use std of stack, 1: use std of frame diff / √2
   prnu_fit: LS                     # LS or WLS regression method
   exclude_abnormal_snr: true       # Ignore low‑SNR patches

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,8 @@ dependencies = [
     "PyYAML>=6.0",
     "psutil>=5.9",
     "imagecodecs>=2023.7",
-    "roifile>=2023.9"
+    "roifile>=2023.9",
+    "scipy>=1.11,<2.0"
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ matplotlib>=3.8,<4.0
 tifffile>=2023.7
 imagecodecs>=2023.7
 roifile>=2023.9          # ← ROI ZIP / ImageJ .roi reader
+scipy>=1.11,<2.0
 
 # GUI
 PySide6>=6.6,<6.7        # or swap for PyQt6 if preferred

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -404,3 +404,12 @@ def test_fit_gain_map_order1_exact():
     mask = np.ones_like(frame, dtype=bool)
     res = analysis.fit_gain_map(frame, mask, order=1)
     assert np.allclose(res, frame / 4.0)
+
+
+def test_fit_gain_map_rbf_basic():
+    pytest.importorskip("scipy")
+    frame = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=float)
+    mask = np.ones_like(frame, dtype=bool)
+    res = analysis.fit_gain_map(frame, mask, order=0, method="rbf")
+    assert res.shape == frame.shape
+    assert np.allclose(np.max(res), 1.0)


### PR DESCRIPTION
## Summary
- add `scipy` to dependencies
- implement `fit_gain_map_rbf` and option in `fit_gain_map`
- support `gain_fit_method` config key
- document RBF usage in README and spec
- test RBF fitting

## Testing
- `black core/analysis.py tests/test_analysis.py --check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a2c07bb28833385432057643b28a0