### PR TITLE
Implement RBF subsampling option

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ For a comprehensive description of each output file, refer to
 	•	Support for multi-gain and multi-exposure batch evaluation
 	•	PRNU and black-level correction logic
         •       `gain_map_mode` normalizes the gain map by its maximum for relative correction
+        •       `rbf_subsample` subsamples pixels before RBF fitting to reduce memory usage
         •       `gain_fit_method` chooses polynomial (`poly`) or radial basis (`rbf`) fitting
 	•	Optional Excel/Markdown export
 	•	CI tests (PyTest + GitHub Actions)

--- a/Sensor_Output_Spec.md
+++ b/Sensor_Output_Spec.md
@@ -52,6 +52,7 @@ Gainごとに下記項目を出力
     * flat_frameはそのGainのフラット画像スタックの平均値を正規化してマップを作成
     * noneはゲインマップ補正なし
   * フィット手法選択: gain_fit_method (poly|rbf)。rbfは計算時間が長くなるため注意
+  * RBFフィット時に画素を間引く rbf_subsample も指定可能
   * フィッティング法：config.processing.prnu\_fit（"LS" or "WLS"）※ μ-σ回帰を行う場合に適用
   * 使用回帰：config.processing.prnu\_fit（"LS" or "WLS"）
     ※ 平均フレームから ROI 平均を引いた残差の空間ばらつきを DSNU と同様の方法で統計化する。ただし PRNU は出力を ROI 平均信号値で正規化する（残差/μ × 100 \[%]）。
@@ -227,6 +228,8 @@ processing:
   gain_map_mode : none        # self_fit | flat_fit | flat_frame | none  PRNUの算出時gain_map補正方法
   plane_fit_order: 2          # ROI内傾斜補正次数
   gain_fit_method: poly       # poly | rbf  フィッティング手法
+  * RBFフィット時に画素を間引く rbf_subsample も指定可能
+  rbf_subsample: 1            # RBFフィット用のサブサンプリング間隔
   read_noise_mode: 0          # 0:スタックstd, 1:差分std/√2
   prnu_fit: LS                # LS:最小二乗法 WLS:加重最小二乗法
   exclude_abnormal_snr: true  # SNRが極端に低いROIを除外

--- a/config/default_config.yaml
+++ b/config/default_config.yaml
@@ -49,6 +49,7 @@ processing:
                                   # gain map is scaled by its maximum
   plane_fit_order: 2               # Polynomial order for plane fitting
   gain_fit_method: poly            # poly | rbf
+  rbf_subsample: 1                # Subsampling step for rbf fitting
   read_noise_mode: 0               # 0: use std of stack, 1: use std of frame diff / √2
   prnu_fit: LS                     # LS or WLS regression method
   exclude_abnormal_snr: true       # Ignore low‑SNR patches


### PR DESCRIPTION
## Summary
- allow RBF plane fitting to subsample the input image
- expose subsampling through config `processing.rbf_subsample`
- document the option in README and spec

## Testing
- `black core/analysis.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a7113b7cc8333abe17a810bca86d6