### PR TITLE
Add random subsampling option for gain fit

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ For a comprehensive description of each output file, refer to
 	•	Support for multi-gain and multi-exposure batch evaluation
 	•	PRNU and black-level correction logic
         •       `gain_map_mode` normalizes the gain map by its maximum for relative correction
-        •       `rbf_subsample` subsamples pixels before RBF fitting to reduce memory usage
+        •       `fit_subsample_step` controls pixel subsampling when fitting gain maps
+        •       `subsample_method` chooses `uniform` or `random` sampling
         •       `gain_fit_method` chooses `poly`, `rbf`, `akima`, or `hermite` fitting
         •       `gain_clip_margin` clips pixels outside margins before fitting
 	•	Optional Excel/Markdown export

--- a/Sensor_Output_Spec.md
+++ b/Sensor_Output_Spec.md
@@ -52,7 +52,7 @@ Gainごとに下記項目を出力
     * flat_frameはそのGainのフラット画像スタックの平均値を正規化してマップを作成
     * noneはゲインマップ補正なし
   * フィット手法選択: gain_fit_method (poly|rbf|akima|hermite)。rbfは計算時間が長くなるため注意
-  * RBFフィット時に画素を間引く rbf_subsample も指定可能
+  * サブサンプリング指定: fit_subsample_step と subsample_method (uniform|random)
   * フィッティング法：config.processing.prnu\_fit（"LS" or "WLS"）※ μ-σ回帰を行う場合に適用
   * 使用回帰：config.processing.prnu\_fit（"LS" or "WLS"）
     ※ 平均フレームから ROI 平均を引いた残差の空間ばらつきを DSNU と同様の方法で統計化する。ただし PRNU は出力を ROI 平均信号値で正規化する（残差/μ × 100 \[%]）。
@@ -228,8 +228,9 @@ processing:
   gain_map_mode : none        # self_fit | flat_fit | flat_frame | none  PRNUの算出時gain_map補正方法
   plane_fit_order: 2          # ROI内傾斜補正次数
   gain_fit_method: poly       # poly | rbf | akima | hermite  フィッティング手法
-  * RBFフィット時に画素を間引く rbf_subsample も指定可能
-  rbf_subsample: 1            # RBFフィット用のサブサンプリング間隔
+  * サブサンプリング指定: fit_subsample_step と subsample_method
+  fit_subsample_step: 1       # フィッティング用のサブサンプル間隔
+  subsample_method: uniform   # uniform または random
   gain_clip_margin: false     # マージン外ピクセルをクリップしてからフィット
   read_noise_mode: 0          # 0:スタックstd, 1:差分std/√2
   prnu_fit: LS                # LS:最小二乗法 WLS:加重最小二乗法

--- a/config/default_config.yaml
+++ b/config/default_config.yaml
@@ -48,8 +48,9 @@ processing:
   gain_map_mode: none              # self_fit | flat_fit | flat_frame | none
                                   # gain map is scaled by its maximum
   plane_fit_order: 2               # Polynomial order for plane fitting
-  gain_fit_method: poly            # poly | rbf
-  rbf_subsample: 1                # Subsampling step for rbf fitting
+  gain_fit_method: poly            # poly | rbf | akima | hermite
+  fit_subsample_step: 1            # Pixel subsample step for gain fitting
+  subsample_method: uniform        # uniform | random sampling mode
   gain_clip_margin: false         # Clip pixels to margins before fitting
   read_noise_mode: 0               # 0: use std of stack, 1: use std of frame diff / √2
   prnu_fit: LS                     # LS or WLS regression method

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -413,3 +413,45 @@ def test_fit_gain_map_rbf_basic():
     res = analysis.fit_gain_map(frame, mask, order=0, method="rbf")
     assert res.shape == frame.shape
     assert np.allclose(np.max(res), 1.0)
+
+
+@pytest.mark.parametrize(
+    "method,order",
+    [
+        ("poly", 1),
+        ("rbf", 0),
+        ("akima", 0),
+        ("hermite", 0),
+    ],
+)
+def test_fit_gain_map_subsample_uniform(method, order):
+    if method != "poly":
+        pytest.importorskip("scipy")
+    frame = np.arange(64, dtype=float).reshape(8, 8)
+    mask = np.ones_like(frame, dtype=bool)
+    res = analysis.fit_gain_map(
+        frame,
+        mask,
+        order=order,
+        method=method,
+        subsample_step=2,
+    )
+    assert res.shape == frame.shape
+
+
+@pytest.mark.parametrize("method,order", [("poly", 1), ("rbf", 0)])
+def test_fit_gain_map_subsample_random(method, order):
+    if method == "rbf":
+        pytest.importorskip("scipy")
+    np.random.seed(0)
+    frame = np.arange(64, dtype=float).reshape(8, 8)
+    mask = np.ones_like(frame, dtype=bool)
+    res = analysis.fit_gain_map(
+        frame,
+        mask,
+        order=order,
+        method=method,
+        subsample_step=2,
+        subsample_method="random",
+    )
+    assert res.shape == frame.shape


### PR DESCRIPTION
## Summary
- rename `processing.rbf_subsample` to `processing.fit_subsample_step`
- support `subsample_method` in gain-map fitting routines
- document new options in README and Sensor_Output_Spec
- test subsampling for various gain fit methods

## Testing
- `black core/analysis.py tests/test_analysis.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a8d5e6f6c83338f9e379fceaf5395