### PR TITLE
Fix DN_sat clamping and update spec

### DIFF
--- a/Sensor_Output_Spec.md
+++ b/Sensor_Output_Spec.md
@@ -63,10 +63,13 @@ Gainごとに下記項目を出力
   * 使用モード：config.processing.read\_noise\_mode
     * 0：スタック全体の標準偏差から計算（デフォルト）
     * 1：フレーム間差分の標準偏差を √2 で割って計算
-* **DN\_sat (飽和DN)**：以下3方式の最大を採用：
+* **DN_sat (飽和DN)**：以下3方式の最大値を採用し、結果は ADC Full Scale DN でクランプする：
 
   1. フラット画像ROIの最大輝度ドットの 99.9 パーセンタイル値
-  2. ADC_FullScaleDN * config.reference.sat\_factor
+  2. フラット画像の最大値を `config.illumination.sat_factor` で割った値
+  3. `ADC_FullScaleDN` × `config.reference.sat_factor`
+
+  `ADC_FullScaleDN` は `(1 << adc_bits) - 1` に `1 << lsb_shift` を乗じた値で定義する。
 * **Dynamic Range (dB)**：最大信号値として DN\_sat を用い、Read Noise (DN) との比から 20\*log10(DN\_sat / Noise) を算出。
 * **SNR @ 50%**：グレースケールチャートまたはフラット画像で、Full-Wellの50%（例：32768 DN）に最も近いμとSNRの系列から、補間または回帰により推定して算出。
   * DN\_satの基準：config.reference.sat\_factor

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -455,3 +455,29 @@ def test_fit_gain_map_subsample_random(method, order):
         subsample_method="random",
     )
     assert res.shape == frame.shape
+
+
+def test_calculate_dn_sat_clamp_full_scale():
+    stack = np.full((2, 2, 2), 65535, dtype=np.uint16)
+    cfg = {
+        "illumination": {"sat_factor": 0.95},
+        "sensor": {"adc_bits": 10, "lsb_shift": 6},
+    }
+    dn_sat = analysis.calculate_dn_sat(stack, cfg)
+    assert dn_sat == ((1 << 10) - 1) * (1 << 6)
+
+
+def test_calculate_dn_sat_uses_lsb_shift():
+    stack = np.full((1, 1, 1), 100, dtype=np.uint16)
+    cfg0 = {
+        "illumination": {"sat_factor": 0.95},
+        "sensor": {"adc_bits": 10, "lsb_shift": 0},
+    }
+    cfg6 = {
+        "illumination": {"sat_factor": 0.95},
+        "sensor": {"adc_bits": 10, "lsb_shift": 6},
+    }
+    dn_sat0 = analysis.calculate_dn_sat(stack, cfg0)
+    dn_sat6 = analysis.calculate_dn_sat(stack, cfg6)
+    assert dn_sat0 == pytest.approx(((1 << 10) - 1) * 0.95)
+    assert dn_sat6 == pytest.approx(((1 << 10) - 1) * (1 << 6) * 0.95)


### PR DESCRIPTION
## Summary
- clamp DN_sat to ADC Full Scale DN
- account for `lsb_shift` in DN_sat calculation
- test DN_sat clamping and lsb_shift use
- document DN_sat calculation in Sensor_Output_Spec.md

## Testing
- `black -q .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683ab083191c833392f094ae4613ae38