### PR TITLE
Fix DN_sat estimation using SNR curve

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -152,6 +152,7 @@ def run_pipeline(
             prnu_data = collect_prnu_points(prnu_stats)
 
             roi_table = extract_roi_table(project, cfg)
+            snr_signal_data = collect_gain_snr_signal(roi_table, cfg)
             flat_roi_file = project / cfg["measurement"].get("flat_roi_file")
             flat_rects = load_rois(flat_roi_file)
 
@@ -214,7 +215,9 @@ def run_pipeline(
                         prnu_map_tmp,
                         gain_map_tmp,
                     )
-                    dn_sat = calculate_dn_sat(flat_stack, cfg)
+                    dn_sat = calculate_dn_sat(
+                        flat_stack, cfg, snr_signal_data.get(gain_db)
+                    )
                     first = False
 
                 # SNR metrics for this gain
@@ -299,7 +302,7 @@ def run_pipeline(
                 "roi_mid_index", cfg.get("measurement", {}).get("roi_mid_index", 5)
             )
             exp_data = collect_mid_roi_snr(roi_table, mid_idx)
-            sig_data = collect_gain_snr_signal(roi_table, cfg)
+            sig_data = snr_signal_data
 
             logging.info("Plotting SNR vs Signal (multi)")
             log_memory_usage("before snr_signal plot: ")

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -495,3 +495,12 @@ def test_calculate_dn_sat_uses_lsb_shift():
     dn_sat6 = analysis.calculate_dn_sat(stack, cfg6)
     assert dn_sat0 == pytest.approx(((1 << 10) - 1) * 0.95)
     assert dn_sat6 == pytest.approx(((1 << 10) - 1) * (1 << 6) * 0.95)
+
+
+def test_calculate_dn_sat_with_snr_signal():
+    stack = np.full((2, 2, 2), 10, dtype=np.uint16)
+    cfg = {"illumination": {"sat_factor": 0.01}, "sensor": {"adc_bits": 10}}
+    signal = np.array([0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100], dtype=float)
+    snr = np.array([1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1], dtype=float)
+    dn_sat = analysis.calculate_dn_sat(stack, cfg, (signal, snr))
+    assert dn_sat == pytest.approx(80.0)


### PR DESCRIPTION
## Summary
- compute SNR vs signal curves before looping over gains
- pass the corresponding curve to `calculate_dn_sat`
- reuse computed SNR data when plotting
- test DN_sat estimation with provided SNR curve

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cf63355f88333b2fe2a927bc9670c