### PR TITLE
Enhance SNR plot with derivative view

### DIFF
--- a/core/plotting.py
+++ b/core/plotting.py
@@ -43,6 +43,24 @@ def _auto_labels(ratios: Sequence[float]) -> list[str]:
     return [f"{r:g}×" for r in ratios]
 
 
+def _smooth_and_second_derivative(
+    signal: np.ndarray, snr: np.ndarray, window: int = 3
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Return smoothed SNR and its second derivative."""
+    idx = np.argsort(signal)
+    sig = np.asarray(signal, dtype=float)[idx]
+    s = np.asarray(snr, dtype=float)[idx]
+    win = max(1, min(window, sig.size))
+    if win > 1:
+        kernel = np.ones(win) / win
+        s_smooth = np.convolve(s, kernel, mode="same")
+    else:
+        s_smooth = s
+    d1 = np.gradient(s_smooth, sig)
+    d2 = np.gradient(d1, sig)
+    return sig, s_smooth, d2
+
+
 def plot_snr_vs_signal(
     signal: np.ndarray,
     snr: np.ndarray,
@@ -83,13 +101,21 @@ def plot_snr_vs_signal_multi(
     output_path: Path,
     *,
     return_fig: bool = False,
+    show_derivative: bool = False,
 ) -> Figure | None:
-    """Plot SNR–Signal curves for multiple gains."""
+    """Plot SNR–Signal curves for multiple gains.
+
+    When ``show_derivative`` is ``True`` an additional subplot is drawn below the
+    main plot showing the second derivative of the smoothed SNR curve.
+    """
     logging.info("plot_snr_vs_signal_multi: output=%s", output_path)
     log_memory_usage("plot start: ")
 
     thresh = cfg.get("processing", {}).get("snr_threshold_dB", 10.0)
-    fig = plt.figure()
+    if show_derivative:
+        fig, (ax_snr, ax_d2) = plt.subplots(2, 1, figsize=(6, 8), sharex=True)
+    else:
+        fig, ax_snr = plt.subplots()
 
     all_signals = []
     for gain, (sig, snr) in sorted(data.items()):
@@ -103,7 +129,19 @@ def plot_snr_vs_signal_multi(
             snr = np.asarray([snr[0] * 0.9, snr[0] * 1.1])
         all_signals.append(sig)
         snr_db = 20 * np.log10(snr)
-        plt.loglog(sig, snr_db, marker="o", linestyle="-", label=f"{gain:g}dB")
+        ax_snr.loglog(sig, snr_db, marker="o", linestyle="-", label=f"{gain:g}dB")
+        if show_derivative:
+            sig_s, snr_smooth, d2 = _smooth_and_second_derivative(sig, snr)
+            color = ax_snr.get_lines()[-1].get_color()
+            ax_snr.loglog(
+                sig_s,
+                20 * np.log10(snr_smooth),
+                linestyle="--",
+                color=color,
+            )
+            ax_d2.semilogx(
+                sig_s, d2, marker=".", linestyle="-", color=color, label=f"{gain:g}dB"
+            )
 
     if all_signals:
         concat = np.concatenate(all_signals)
@@ -113,15 +151,21 @@ def plot_snr_vs_signal_multi(
             xs = np.asarray([x_min * 0.9, x_max * 1.1])
         else:
             xs = np.linspace(x_min, x_max, 200)
-        plt.loglog(xs, 20 * np.log10(np.sqrt(xs)), linestyle=":", label="Ideal √µ")
+        ax_snr.loglog(xs, 20 * np.log10(np.sqrt(xs)), linestyle=":", label="Ideal √µ")
 
-    plt.axhline(thresh, color="r", linestyle="--", label=f"{thresh:g} dB")
-    plt.xlabel("Signal (DN)")
-    plt.ylabel("SNR (dB)")
-    plt.title("SNR vs Signal")
-    plt.grid(True, which="both")
-    plt.legend()
-    plt.tight_layout()
+    ax_snr.axhline(thresh, color="r", linestyle="--", label=f"{thresh:g} dB")
+    ax_snr.set_xlabel("Signal (DN)")
+    ax_snr.set_ylabel("SNR (dB)")
+    ax_snr.set_title("SNR vs Signal")
+    ax_snr.grid(True, which="both")
+    ax_snr.legend()
+    if show_derivative:
+        ax_d2.set_xlabel("Signal (DN)")
+        ax_d2.set_ylabel("d²SNR / dDN²")
+        ax_d2.set_title("Second Derivative")
+        ax_d2.grid(True, which="both")
+        ax_d2.legend()
+    fig.tight_layout()
     fig.savefig(output_path)
     if return_fig:
         log_memory_usage("plot end: ")

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -321,7 +321,11 @@ def run_pipeline(
             logging.info("Plotting SNR vs Signal (multi)")
             log_memory_usage("before snr_signal plot: ")
             fig_snr_signal = plot_snr_vs_signal_multi(
-                sig_data, cfg, out_dir / "snr_signal.png", return_fig=True
+                sig_data,
+                cfg,
+                out_dir / "snr_signal.png",
+                return_fig=True,
+                show_derivative=True,
             )
             log_memory_usage("after snr_signal plot: ")
 

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -44,6 +44,15 @@ def test_plot_snr_vs_signal_multi_single_point(tmp_path):
     assert (tmp_path / "single_multi.png").is_file()
 
 
+def test_plot_snr_vs_signal_multi_derivative(tmp_path):
+    data = {0.0: (np.array([1.0, 2.0, 3.0]), np.array([2.0, 4.0, 6.0]))}
+    fig = plotting.plot_snr_vs_signal_multi(
+        data, {}, tmp_path / "deriv.png", return_fig=True, show_derivative=True
+    )
+    assert (tmp_path / "deriv.png").is_file()
+    assert len(fig.axes) == 2
+
+
 def test_plot_snr_vs_signal_multi_invalid(tmp_path):
     data = {0.0: (np.array([1.0]), np.array([-1.0]))}
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary
- draw smoothed curve and second derivative below SNR vs Signal plot
- expose `show_derivative` option in plotting API
- enable derivative view in GUI
- test new plotting feature

## Testing
- `black core/plotting.py gui/main_window.py tests/test_plotting.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683db22ed2008333a8f37ed784b6acf4