### PR TITLE
Improve saturation estimation with close signal levels

### DIFF
--- a/core/analysis.py
+++ b/core/analysis.py
@@ -1011,8 +1011,43 @@ def _estimate_sat_from_snr(signal: np.ndarray, snr: np.ndarray) -> float:
             np.array2string(diffs[close_idx], precision=3, threshold=10),
         )
 
+        # merge consecutive points closer than 1 DN by averaging
+        merged_sig = []
+        merged_s = []
+        i = 0
+        while i < sig.size:
+            j = i + 1
+            while j < sig.size and abs(sig[j] - sig[j - 1]) < 1.0:
+                j += 1
+            if j - i > 1:
+                merged_sig.append(float(np.mean(sig[i:j])))
+                merged_s.append(float(np.mean(s[i:j])))
+            else:
+                merged_sig.append(float(sig[i]))
+                merged_s.append(float(s[i]))
+            i = j
+        sig = np.asarray(merged_sig)
+        s = np.asarray(merged_s)
+
+    # remove any remaining duplicates exactly equal
+    uniq_sig, inv_idx = np.unique(sig, return_inverse=True)
+    if uniq_sig.size != sig.size:
+        uniq_s = [float(np.mean(s[inv_idx == i])) for i in range(uniq_sig.size)]
+        sig = uniq_sig
+        s = np.asarray(uniq_s)
+
     if sig.size >= 4:
-        spline = UnivariateSpline(sig, s, s=0.2, k=3)
+        s_val = 0.2
+        try:
+            spline = UnivariateSpline(sig, s, s=s_val, k=3)
+        except Exception as exc:  # pragma: no cover - should not normally fail
+            s_val = float(sig.size) * 0.1
+            logging.debug(
+                "_estimate_sat_from_snr: spline retry with s=%.3f due to %s",
+                s_val,
+                exc,
+            )
+            spline = UnivariateSpline(sig, s, s=s_val, k=3)
         d2 = spline.derivative(2)(sig)
         logging.debug(
             "_estimate_sat_from_snr: second derivative=%s",

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -504,3 +504,19 @@ def test_calculate_dn_sat_with_snr_signal():
     snr = np.array([1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1], dtype=float)
     dn_sat = analysis.calculate_dn_sat(stack, cfg, (signal, snr))
     assert dn_sat == pytest.approx(80.0)
+
+
+def test_calculate_dn_sat_close_points_no_warning():
+    stack = np.full((2, 2, 2), 10, dtype=np.uint16)
+    cfg = {"illumination": {"sat_factor": 0.01}, "sensor": {"adc_bits": 10}}
+    signal = np.array(
+        [0, 10, 20, 30, 40, 50, 60, 70, 79.9, 80.0, 80.1, 90, 100], dtype=float
+    )
+    snr = np.array([1, 2, 3, 4, 5, 6, 5, 4, 3.1, 3.0, 2.9, 2, 1], dtype=float)
+    import warnings
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        dn_sat = analysis.calculate_dn_sat(stack, cfg, (signal, snr))
+    assert not w
+    assert dn_sat == pytest.approx(80.0)


### PR DESCRIPTION
## Summary
- average adjacent signal levels that are closer than 1 DN
- remove duplicates before spline and retry with higher `s` if needed
- add regression test for close signal points without warnings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683de57ee0b48333b2657273b2feb0c0