### PR TITLE
Add noise vs signal plots

### DIFF
--- a/core/analysis.py
+++ b/core/analysis.py
@@ -33,6 +33,7 @@ __all__ = [
     "calculate_system_sensitivity",
     "collect_mid_roi_snr",
     "collect_gain_snr_signal",
+    "collect_gain_noise_signal",
     "collect_prnu_points",
     "calculate_dn_at_snr",
     "calculate_snr_at_half",
@@ -801,6 +802,30 @@ def collect_gain_snr_signal(
         items.sort(key=lambda x: x[0])
         sig, s = zip(*items)
         res[gain] = (np.array(sig), np.array(s))
+    return res
+
+
+def collect_gain_noise_signal(
+    rows: List[Dict[str, Any]],
+    cfg: Dict[str, Any],
+    black_levels: Dict[float, float] | None = None,
+) -> Dict[float, tuple[np.ndarray, np.ndarray]]:
+    """Return noise curves indexed by signal level for each gain using ROI rows."""
+
+    data: Dict[float, list[tuple[float, float]]] = {}
+    for row in rows:
+        mean = float(row.get("Mean", 0.0))
+        std = float(row.get("Std", 0.0))
+        if std == 0:
+            continue
+        gain = float(row.get("Gain (dB)", 0.0))
+        data.setdefault(gain, []).append((mean, std))
+
+    res: Dict[float, tuple[np.ndarray, np.ndarray]] = {}
+    for gain, items in data.items():
+        items.sort(key=lambda x: x[0])
+        sig, n = zip(*items)
+        res[gain] = (np.array(sig), np.array(n))
     return res
 
 

--- a/core/plotting.py
+++ b/core/plotting.py
@@ -27,6 +27,7 @@ __all__ = [
     "plot_prnu_regression",
     "plot_heatmap",
     "plot_roi_area",
+    "plot_noise_vs_signal_multi",
 ]
 
 
@@ -282,6 +283,39 @@ def plot_snr_vs_signal_multi(
         return fig
     plt.close(fig)
     log_memory_usage("plot end: ")
+    return None
+
+
+def plot_noise_vs_signal_multi(
+    data: Dict[float, tuple[np.ndarray, np.ndarray]],
+    cfg: Dict[str, Any],
+    output_path: Path,
+    *,
+    return_fig: bool = False,
+) -> Figure | None:
+    """Plot Noise–Signal curves for multiple gains."""
+
+    logging.info("plot_noise_vs_signal_multi: output=%s", output_path)
+    fig, ax = plt.subplots()
+
+    for gain, (sig, noise) in sorted(data.items()):
+        sig = _validate_positive_finite(sig, "signal")
+        noise = _validate_positive_finite(noise, "noise")
+        if sig.size == 1 or noise.size == 1:
+            sig = np.asarray([sig[0] * 0.9, sig[0] * 1.1])
+            noise = np.asarray([noise[0] * 0.9, noise[0] * 1.1])
+        ax.loglog(sig, noise, marker="o", linestyle="-", label=f"{gain:g}dB")
+
+    ax.set_xlabel("Signal (DN)")
+    ax.set_ylabel("Noise (DN)")
+    ax.set_title("Noise vs Signal")
+    ax.grid(True, which="both")
+    ax.legend()
+    fig.tight_layout()
+    fig.savefig(output_path)
+    if return_fig:
+        return fig
+    plt.close(fig)
     return None
 
 

--- a/core/report_gen.py
+++ b/core/report_gen.py
@@ -164,7 +164,7 @@ def report_html(
     html.append(summary_text)
     html.append("</pre>")
     groups = [
-        ("snr_signal",),
+        ("snr_signal", "noise_signal"),
         ("snr_exposure",),
         ("prnu_fit",),
         ("dsnu_map", "dsnu_map_scaled"),

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -56,6 +56,7 @@ from core.analysis import (
     calculate_system_sensitivity,
     collect_mid_roi_snr,
     collect_gain_snr_signal,
+    collect_gain_noise_signal,
     collect_prnu_points,
     calculate_dn_at_snr,
     calculate_snr_at_half,
@@ -66,6 +67,7 @@ from core.analysis import (
 )
 from core.plotting import (
     plot_snr_vs_signal_multi,
+    plot_noise_vs_signal_multi,
     plot_snr_vs_exposure,
     plot_prnu_regression,
     plot_heatmap,
@@ -168,6 +170,7 @@ def run_pipeline(
 
             roi_table = extract_roi_table(project, cfg)
             snr_signal_data = collect_gain_snr_signal(roi_table, cfg, black_levels)
+            noise_signal_data = collect_gain_noise_signal(roi_table, cfg, black_levels)
             flat_roi_file = project / cfg["measurement"].get("flat_roi_file")
             flat_rects = load_rois(flat_roi_file)
 
@@ -354,6 +357,15 @@ def run_pipeline(
             )
             log_memory_usage("after snr_signal plot: ")
 
+            logging.info("Plotting Noise vs Signal (multi)")
+            fig_noise_signal = plot_noise_vs_signal_multi(
+                noise_signal_data,
+                cfg,
+                out_dir / "noise_signal.png",
+                return_fig=True,
+            )
+            log_memory_usage("after noise_signal plot: ")
+
             logging.info("Plotting SNR vs Exposure")
             log_memory_usage("before snr_exposure plot: ")
             fig_snr_exposure = plot_snr_vs_exposure(
@@ -449,6 +461,7 @@ def run_pipeline(
 
             graphs = {
                 "snr_signal": out_dir / "snr_signal.png",
+                "noise_signal": out_dir / "noise_signal.png",
                 "snr_exposure": out_dir / "snr_exposure.png",
                 "prnu_fit": out_dir / "prnu_fit.png",
                 "dsnu_map": out_dir / "dsnu_map.png",
@@ -462,6 +475,7 @@ def run_pipeline(
             }
             figures = {
                 "snr_signal": fig_snr_signal,
+                "noise_signal": fig_noise_signal,
                 "snr_exposure": fig_snr_exposure,
                 "prnu_fit": fig_prnu_fit,
                 "dsnu_map": fig_dsnu_map,
@@ -618,7 +632,7 @@ class MainWindow(QMainWindow):
         self.graph_tabs.clear()
 
         graph_groups = {
-            "SNR-Signal": ["snr_signal"],
+            "SNR-Signal": ["snr_signal", "noise_signal"],
             "SNR-Exposure": ["snr_exposure"],
             "PRNU Fit": ["prnu_fit"],
             "DSNU Map": ["dsnu_map", "dsnu_map_scaled"],

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -109,6 +109,28 @@ def test_collect_gain_snr_signal_rows():
     assert np.allclose(snr, [9.0, 9.5])
 
 
+def test_collect_gain_noise_signal_rows():
+    rows = [
+        {
+            "Gain (dB)": 0.0,
+            "Exposure": 1.0,
+            "Mean": 10.0,
+            "Std": 1.0,
+        },
+        {
+            "Gain (dB)": 0.0,
+            "Exposure": 2.0,
+            "Mean": 20.0,
+            "Std": 2.0,
+        },
+    ]
+    cfg = {}
+    data = analysis.collect_gain_noise_signal(rows, cfg)
+    sig, noise = data[0.0]
+    assert np.allclose(sig, [10.0, 20.0])
+    assert np.allclose(noise, [1.0, 2.0])
+
+
 def test_extract_roi_stats_mid_index(tmp_path):
     def _roiread_multi(path):
         class _R:

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -93,6 +93,21 @@ def test_plot_snr_vs_signal_multi_invalid(tmp_path):
         )
 
 
+def test_plot_noise_vs_signal_multi(tmp_path):
+    data = {
+        0.0: (np.array([1.0, 2.0]), np.array([0.5, 1.0])),
+        6.0: (np.array([1.5, 3.0]), np.array([0.7, 1.4])),
+    }
+    plotting.plot_noise_vs_signal_multi(data, {}, tmp_path / "noise.png")
+    assert (tmp_path / "noise.png").is_file()
+
+
+def test_plot_noise_vs_signal_multi_invalid(tmp_path):
+    data = {0.0: (np.array([1.0, -2.0]), np.array([0.5, 1.0]))}
+    with pytest.raises(ValueError):
+        plotting.plot_noise_vs_signal_multi(data, {}, tmp_path / "bad2.png")
+
+
 def test_plot_roi_area(tmp_path):
     img = np.zeros((4, 4))
     rects = [[(0, 0, 2, 2)], [(1, 1, 2, 2)], []]


### PR DESCRIPTION
## Summary
- plot noise vs signal alongside SNR graphs
- collect noise vs signal data from ROI table
- include the new graph in HTML report and GUI tabs
- test new analysis and plotting functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683eb350d0c883339d6f17d32d22a2cb