### PR TITLE
Improve SNR fitting

### DIFF
--- a/core/analysis.py
+++ b/core/analysis.py
@@ -1529,16 +1529,30 @@ def clipped_snr_model(
     read_noise: float,
     adc_full_scale: float,
     black_level: float = 0.0,
+    *,
+    limit_noise: float = 0.0,
+    limit_margin: float = 0.05,
 ) -> np.ndarray:
-    """Return SNR curve accounting for ADC clipping and black level."""
+    """Return SNR curve accounting for ADC clipping and black level.
+
+    Additional ``limit_noise`` can be injected only when the signal is close to
+    ``black_level`` or ``adc_full_scale``. The affected region is controlled by
+    ``limit_margin`` which specifies the fraction of the usable range.
+    """
 
     from scipy.stats import norm
 
     sig = np.asarray(signal, dtype=float) - black_level
     sig_pos = np.maximum(sig, 0.0)
-    sigma = np.sqrt(sig_pos + read_noise**2)
+    range_val = adc_full_scale - black_level
+    if limit_noise > 0.0 and limit_margin > 0.0:
+        margin = limit_margin * range_val
+        edge_mask = (sig_pos < margin) | ((range_val - sig_pos) < margin)
+    else:
+        edge_mask = np.zeros_like(sig_pos, dtype=bool)
+    sigma = np.sqrt(sig_pos + read_noise**2 + (limit_noise**2) * edge_mask)
     alpha = (0.0 - sig) / sigma
-    beta = (adc_full_scale - black_level - sig) / sigma
+    beta = (range_val - sig) / sigma
     cdf = norm.cdf
     pdf = norm.pdf
     with np.errstate(divide="ignore", invalid="ignore"):
@@ -1560,8 +1574,16 @@ def fit_clipped_snr_model(
     snr: np.ndarray,
     adc_full_scale: float,
     black_level: float = 0.0,
-) -> float:
-    """Fit :func:`clipped_snr_model` and return estimated read noise."""
+    *,
+    limit_noise: float | None = None,
+    limit_margin: float = 0.05,
+) -> tuple[float, float]:
+    """Fit :func:`clipped_snr_model` and return estimated ``(read_noise, limit_noise)``.
+
+    If ``limit_noise`` is ``None``, both ``read_noise`` and ``limit_noise`` are
+    optimized. Otherwise ``limit_noise`` is kept fixed and only ``read_noise`` is
+    estimated.
+    """
 
     signal = np.asarray(signal, dtype=float)
     snr = np.asarray(snr, dtype=float)
@@ -1573,13 +1595,45 @@ def fit_clipped_snr_model(
     # Avoid discarding high-SNR points. They may indicate clipped noise rather
     # than measurement errors, so include all finite samples in the fit.
 
+    if limit_noise is None:
+
+        def _model(x: np.ndarray, r: float, ln: float) -> np.ndarray:
+            return clipped_snr_model(
+                x,
+                r,
+                adc_full_scale,
+                black_level,
+                limit_noise=ln,
+                limit_margin=limit_margin,
+            )
+
+        try:
+            popt, _ = curve_fit(
+                _model,
+                signal,
+                snr,
+                p0=[1.0, 0.1],
+                bounds=([0.0, 0.0], [np.inf, np.inf]),
+                maxfev=10000,
+            )
+        except Exception:
+            return 1.0, 0.0
+        return float(popt[0]), float(popt[1])
+
     def _model(x: np.ndarray, r: float) -> np.ndarray:
-        return clipped_snr_model(x, r, adc_full_scale, black_level)
+        return clipped_snr_model(
+            x,
+            r,
+            adc_full_scale,
+            black_level,
+            limit_noise=limit_noise,
+            limit_margin=limit_margin,
+        )
 
     try:
         popt, _ = curve_fit(
             _model, signal, snr, p0=[1.0], bounds=(0.0, np.inf), maxfev=10000
         )
     except Exception:
-        return 1.0
-    return float(popt[0])
+        return 1.0, float(limit_noise)
+    return float(popt[0]), float(limit_noise)

--- a/core/plotting.py
+++ b/core/plotting.py
@@ -239,9 +239,17 @@ def plot_snr_vs_signal_multi(
         )
 
         bl = 0.0 if black_levels is None else float(black_levels.get(gain, 0.0))
-        rn = analysis.fit_clipped_snr_model(sig, snr, adc_full_scale, black_level=bl)
+        rn, ln = analysis.fit_clipped_snr_model(
+            sig, snr, adc_full_scale, black_level=bl
+        )
         xs = np.linspace(float(sig.min()), float(sig.max()), 200)
-        snr_fit = analysis.clipped_snr_model(xs, rn, adc_full_scale, black_level=bl)
+        snr_fit = analysis.clipped_snr_model(
+            xs,
+            rn,
+            adc_full_scale,
+            black_level=bl,
+            limit_noise=ln,
+        )
         ax_snr.loglog(
             xs, 20 * np.log10(snr_fit), linestyle="-", color=color, label="_nolegend_"
         )

--- a/core/report_gen.py
+++ b/core/report_gen.py
@@ -216,9 +216,17 @@ def save_snr_signal_json(
         out: Dict[str, Any] = {}
         for gain, (sig, snr) in sorted(data.items()):
             bl = 0.0 if black_levels is None else float(black_levels.get(gain, 0.0))
-            rn = analysis.fit_clipped_snr_model(sig, snr, full_scale, black_level=bl)
+            rn, ln = analysis.fit_clipped_snr_model(
+                sig, snr, full_scale, black_level=bl
+            )
             xs = np.linspace(float(sig.min()), float(sig.max()), 200)
-            snr_fit = analysis.clipped_snr_model(xs, rn, full_scale, black_level=bl)
+            snr_fit = analysis.clipped_snr_model(
+                xs,
+                rn,
+                full_scale,
+                black_level=bl,
+                limit_noise=ln,
+            )
             out[f"{gain:g}"] = {
                 "signal": sig.tolist(),
                 "snr": snr.tolist(),

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -541,3 +541,22 @@ def test_clipped_snr_model_black_level_effect():
     assert snr_bl[0] > 1e6
     assert snr_bl[0] > snr_bl[1]
     assert snr_no_bl[0] < snr_no_bl[1]
+
+
+def test_clipped_snr_model_limit_noise_effect():
+    sig = np.array([5.0, 50.0, 95.0])
+    snr_base = analysis.clipped_snr_model(sig, 1.0, 100.0)
+    snr_lim = analysis.clipped_snr_model(
+        sig, 1.0, 100.0, limit_noise=5.0, limit_margin=0.1
+    )
+    assert snr_lim[0] < snr_base[0]
+    assert snr_lim[1] == pytest.approx(snr_base[1])
+    assert snr_lim[2] < snr_base[2]
+
+
+def test_fit_clipped_snr_model_estimates_limit_noise():
+    sig = np.linspace(0, 100, 20)
+    snr = analysis.clipped_snr_model(sig, 2.0, 100.0, limit_noise=5.0, limit_margin=0.1)
+    rn, ln = analysis.fit_clipped_snr_model(sig, snr, 100.0, limit_margin=0.1)
+    assert rn == pytest.approx(2.0, rel=0.1)
+    assert ln == pytest.approx(5.0, rel=0.1)


### PR DESCRIPTION
## Summary
- estimate `limit_noise` automatically when fitting SNR
- plot functions handle `(read_noise, limit_noise)` result
- include `limit_noise` when saving fitted curves
- test automatic `limit_noise` estimation

## Testing
- `black core/analysis.py core/plotting.py core/report_gen.py tests/test_analysis.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683eb3d3cc84833388cfe91db65ae5d9