### PR TITLE
Implement three-region SNR fitting

### DIFF
--- a/core/plotting.py
+++ b/core/plotting.py
@@ -240,16 +240,8 @@ def plot_snr_vs_signal_multi(
         )
 
         bl = 0.0 if black_levels is None else float(black_levels.get(gain, 0.0))
-        rn, ln = analysis.fit_clipped_snr_model(
+        xs, snr_fit = analysis.fit_three_region_snr_model(
             sig, snr, adc_full_scale, black_level=bl
-        )
-        xs = np.linspace(float(sig.min()), float(sig.max()), 200)
-        snr_fit = analysis.clipped_snr_model(
-            xs,
-            rn,
-            adc_full_scale,
-            black_level=bl,
-            limit_noise=ln,
         )
         ax_snr.loglog(
             xs, 20 * np.log10(snr_fit), linestyle="-", color=color, label="_nolegend_"

--- a/core/report_gen.py
+++ b/core/report_gen.py
@@ -216,16 +216,8 @@ def save_snr_signal_json(
         out: Dict[str, Any] = {}
         for gain, (sig, snr) in sorted(data.items()):
             bl = 0.0 if black_levels is None else float(black_levels.get(gain, 0.0))
-            rn, ln = analysis.fit_clipped_snr_model(
+            xs, snr_fit = analysis.fit_three_region_snr_model(
                 sig, snr, full_scale, black_level=bl
-            )
-            xs = np.linspace(float(sig.min()), float(sig.max()), 200)
-            snr_fit = analysis.clipped_snr_model(
-                xs,
-                rn,
-                full_scale,
-                black_level=bl,
-                limit_noise=ln,
             )
             out[f"{gain:g}"] = {
                 "signal": sig.tolist(),

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -582,3 +582,12 @@ def test_fit_clipped_snr_model_estimates_limit_noise():
     rn, ln = analysis.fit_clipped_snr_model(sig, snr, 100.0, limit_margin=0.1)
     assert rn == pytest.approx(2.0, rel=0.1)
     assert ln == pytest.approx(5.0, rel=0.1)
+
+
+def test_fit_three_region_snr_model_basic():
+    sig = np.linspace(0, 100, 20)
+    snr = analysis.clipped_snr_model(sig, 2.0, 100.0)
+    xs, fit = analysis.fit_three_region_snr_model(sig, snr, 100.0)
+    assert xs.shape == (200,)
+    assert fit.shape == (200,)
+    assert np.isfinite(fit).all()


### PR DESCRIPTION
## Summary
- add `fit_three_region_snr_model` for improved SNR vs Signal fitting
- use the new model in plotting and JSON export
- test the new function

## Testing
- `black . --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f2505135c8333b8ae6a3317bbe835