### PR TITLE
Add dummy libmkepicam module

### DIFF
--- a/libmkepicam/__init__.py
+++ b/libmkepicam/__init__.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import numpy as np
+
+
+class DummyMkEpiCam:
+    """Simple dummy for libmkepicam camera functions."""
+
+    def __init__(self, width: int = 640, height: int = 480) -> None:
+        self.width = width
+        self.height = height
+        self._opened = False
+
+    def open(self) -> bool:
+        self._opened = True
+        return True
+
+    def close(self) -> None:
+        self._opened = False
+
+    def capture_frame(self) -> np.ndarray:
+        if not self._opened:
+            raise RuntimeError("Camera not opened")
+        return np.zeros((self.height, self.width), dtype=np.uint16)
+
+
+_camera = DummyMkEpiCam()
+
+
+def open_camera() -> bool:
+    return _camera.open()
+
+
+def close_camera() -> None:
+    _camera.close()
+
+
+def grab_frame() -> np.ndarray:
+    return _camera.capture_frame()

--- a/tests/test_libmkepicam.py
+++ b/tests/test_libmkepicam.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import numpy as np
+import libmkepicam as cam
+
+
+def test_open_close_cycle():
+    assert cam.open_camera()
+    cam.close_camera()
+
+
+def test_grab_frame_returns_array():
+    cam.open_camera()
+    frame = cam.grab_frame()
+    cam.close_camera()
+    assert isinstance(frame, np.ndarray)
+    assert frame.shape == (480, 640)
+    assert frame.dtype == np.uint16


### PR DESCRIPTION
## Summary
- add simple dummy library `libmkepicam` with open/close/grab API
- new test to verify dummy behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fd75130548333bc45d8b6818e7ac1