### PR TITLE
Remove second derivative plot

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -342,7 +342,6 @@ def run_pipeline(
                 cfg,
                 out_dir / "snr_signal.png",
                 return_fig=True,
-                show_derivative=True,
                 interp_points=cfgutil.adc_full_scale(cfg),
                 black_levels=black_levels,
             )

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -54,20 +54,6 @@ def test_plot_snr_vs_signal_multi_single_point(tmp_path):
     assert (tmp_path / "single_multi.png").is_file()
 
 
-def test_plot_snr_vs_signal_multi_derivative(tmp_path):
-    data = {0.0: (np.array([1.0, 2.0, 3.0]), np.array([2.0, 4.0, 6.0]))}
-    fig = plotting.plot_snr_vs_signal_multi(
-        data,
-        {},
-        tmp_path / "deriv.png",
-        return_fig=True,
-        show_derivative=True,
-        black_levels={0.0: 0.0},
-    )
-    assert (tmp_path / "deriv.png").is_file()
-    assert len(fig.axes) == 2
-
-
 def test_plot_snr_vs_signal_multi_interp(tmp_path):
     data = {0.0: (np.array([1.0, 3.0]), np.array([2.0, 6.0]))}
     fig = plotting.plot_snr_vs_signal_multi(


### PR DESCRIPTION
## Summary
- drop `_smooth_and_second_derivative` helper and derivative plotting
- remove `show_derivative` option from `plot_snr_vs_signal_multi`
- update GUI caller and tests

## Testing
- `black core/plotting.py gui/main_window.py tests/test_plotting.py --check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684072234b4083338dbe3b72275af8a3