### PR TITLE
Document robust_p_spline_fit API

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,22 @@ Run the GUI using `python main.py`
 For a comprehensive description of each output file, refer to
 [Sensor_Output_Spec.md](Sensor_Output_Spec.md).
 
+##📐 Robust P-spline SNR Fitting
+
+The SNR curves can be smoothed using the `utils.robust_pspline.robust_p_spline_fit`
+function. It performs robust P-spline regression with automatic parameter search
+and returns the fitted curve together with a 95% confidence interval.  Typical
+usage for an array of signal levels `x` and SNR values `y` is:
+
+```python
+from utils.robust_pspline import robust_p_spline_fit
+
+x_dense, y_pred, upper, lower = robust_p_spline_fit(x, y)
+```
+
+The resulting `x_dense` and `y_pred` arrays can be plotted to visualize the
+smoothed SNR curve, while `upper` and `lower` provide the confidence bounds.
+
 ##🔮 Planned Features
 
 	•	ROI/pixel mode switching in GUI

--- a/Sensor_Output_Spec.md
+++ b/Sensor_Output_Spec.md
@@ -69,10 +69,10 @@ Gainごとに下記項目を出力
   から得られるしきい値と比較して最大値を採用し、結果を `ADC_FullScaleDN` でクランプ
   する。`ADC_FullScaleDN` は `(1 << adc_bits) - 1` に `1 << lsb_shift` を乗じた値とする。
 * **Dynamic Range (dB)**：最大信号値として DN\_sat を用い、Read Noise (DN) との比から 20\*log10(DN\_sat / Noise) を算出。
-* **SNR @ 50%**：グレースケールチャートまたはフラット画像で、Full-Wellの50%（例：32768 DN）に最も近いμとSNRの系列から、補間または回帰により推定して算出。
+* **SNR @ 50%**：グレースケールチャートまたはフラット画像で、Full-Wellの50%（例：32768 DN）に最も近いμとSNRの系列から、`utils.robust_pspline.robust_p_spline_fit` を利用したロバストPスプライン回帰で推定して算出。
   * DN\_satの基準：config.reference.sat\_factor
-* **DN @ SNR=10dB**：SNRカーブから、SNRが10dB（config.processing.snr\_threshold\_dB）を超える最小DN値を補間または回帰で推定。
-* **DN @ SNR=1 (0 dB)**：SNRが1となる最小信号レベル（ノイズと等価）を補間または回帰で推定。
+* **DN @ SNR=10dB**：SNRカーブから、SNRが10dB（config.processing.snr\_threshold\_dB）を超える最小DN値をPスプライン回帰曲線から推定。
+* **DN @ SNR=1 (0 dB)**：SNRが1となる最小信号レベル（ノイズと等価）を同回帰曲線から推定。
 
 #### 2. `roi_stats.csv`
 

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -43,7 +43,9 @@ def test_calculate_dark_noise_gain(tmp_path):
     gain_dir.mkdir(parents=True)
 
     for i in range(2):
-        tifffile.imwrite(gain_dir / f"frame{i}.tiff", np.full((2, 2), i, dtype=np.uint16))
+        tifffile.imwrite(
+            gain_dir / f"frame{i}.tiff", np.full((2, 2), i, dtype=np.uint16)
+        )
 
     roi_file = project / "roi.roi"
     roi_file.write_text("dummy")
@@ -62,7 +64,9 @@ def test_calculate_dark_noise_gain(tmp_path):
 
     cfg = load_config(cfg_file)
 
-    dsnu, rn, dsnu_map, rn_map, black = analysis.calculate_dark_noise_gain(project, 0, cfg)
+    dsnu, rn, dsnu_map, rn_map, black = analysis.calculate_dark_noise_gain(
+        project, 0, cfg
+    )
 
     assert pytest.approx(dsnu, abs=1e-6) == 0.0
     assert pytest.approx(rn, abs=1e-6) == 0.5
@@ -539,7 +543,9 @@ def test_clear_cache_resets_internal_caches():
 def test_calculate_dn_sat_close_points_no_warning():
     stack = np.full((2, 2, 2), 10, dtype=np.uint16)
     cfg = {"illumination": {"sat_factor": 0.01}, "sensor": {"adc_bits": 10}}
-    signal = np.array([0, 10, 20, 30, 40, 50, 60, 70, 79.9, 80.0, 80.1, 90, 100], dtype=float)
+    signal = np.array(
+        [0, 10, 20, 30, 40, 50, 60, 70, 79.9, 80.0, 80.1, 90, 100], dtype=float
+    )
     noise = np.array([1, 2, 3, 4, 5, 6, 7, 8, 4, 3, 2, 1, 0.5], dtype=float)
     import warnings
 
@@ -562,7 +568,9 @@ def test_clipped_snr_model_black_level_effect():
 def test_clipped_snr_model_limit_noise_effect():
     sig = np.array([5.0, 50.0, 95.0])
     snr_base = analysis.clipped_snr_model(sig, 1.0, 100.0)
-    snr_lim = analysis.clipped_snr_model(sig, 1.0, 100.0, limit_noise=5.0, limit_margin=0.1)
+    snr_lim = analysis.clipped_snr_model(
+        sig, 1.0, 100.0, limit_noise=5.0, limit_margin=0.1
+    )
     assert snr_lim[0] < snr_base[0]
     assert snr_lim[1] == pytest.approx(snr_base[1])
     assert snr_lim[2] < snr_base[2]


### PR DESCRIPTION
## Summary
- document usage of `robust_p_spline_fit` in README
- mention robust P-spline fitting in Sensor_Output_Spec
- format tests with `black`

## Testing
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68407a440bc08333b494d297c5b60237