### PR TITLE
Remove unused single SNR plot

### DIFF
--- a/core/plotting.py
+++ b/core/plotting.py
@@ -19,7 +19,6 @@ from core import analysis
 from utils import config as cfgutil
 
 __all__ = [
-    "plot_snr_vs_signal",
     "plot_snr_vs_signal_multi",
     "plot_snr_vs_exposure",
     "plot_prnu_regression",
@@ -43,40 +42,6 @@ def _validate_positive_finite(arr: np.ndarray, name: str) -> np.ndarray:
 
 def _auto_labels(ratios: Sequence[float]) -> list[str]:
     return [f"{r:g}×" for r in ratios]
-
-
-def plot_snr_vs_signal(
-    signal: np.ndarray,
-    snr: np.ndarray,
-    cfg: Dict[str, Any],
-    output_path: Path,
-    *,
-    return_fig: bool = False,
-) -> Figure | None:
-    """Plot SNR–Signal curve (log–log) with ideal line and threshold."""
-    signal = _validate_positive_finite(signal, "signal")
-    snr = _validate_positive_finite(snr, "snr")
-    if signal.size == 1 or snr.size == 1:
-        # Avoid singular log scale when only one sample is present
-        signal = np.asarray([signal[0] * 0.9, signal[0] * 1.1])
-        snr = np.asarray([snr[0] * 0.9, snr[0] * 1.1])
-    thresh = cfg.get("processing", {}).get("snr_threshold_dB", 10.0)
-    snr_db = 20 * np.log10(snr)
-    fig = plt.figure()
-    plt.loglog(signal, snr_db, marker="o", linestyle="-", label="Measured")
-    plt.loglog(signal, 20 * np.log10(np.sqrt(signal)), linestyle=":", label="Ideal √µ")
-    plt.axhline(thresh, color="r", linestyle="--", label=f"{thresh:g} dB")
-    plt.xlabel("Signal (DN)")
-    plt.ylabel("SNR (dB)")
-    plt.title("SNR vs Signal")
-    plt.grid(True, which="both")
-    plt.legend()
-    plt.tight_layout()
-    fig.savefig(output_path)
-    if return_fig:
-        return fig
-    plt.close(fig)
-    return None
 
 
 def plot_snr_vs_signal_multi(

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -6,24 +6,10 @@ np = pytest.importorskip("numpy")
 from core import plotting
 
 
-def test_plot_snr_vs_signal_invalid(tmp_path):
-    sig = np.array([1.0, 0.0, 3.0])
-    snr = np.array([1.0, 2.0, 3.0])
-    with pytest.raises(ValueError):
-        plotting.plot_snr_vs_signal(sig, snr, {}, tmp_path / "out.png")
-
-
 def test_plot_snr_vs_exposure_invalid(tmp_path):
     data = {0.0: (np.array([1.0, -2.0]), np.array([1.0, 2.0]))}
     with pytest.raises(ValueError):
         plotting.plot_snr_vs_exposure(data, {}, tmp_path / "out.png")
-
-
-def test_plot_snr_vs_signal_single_point(tmp_path):
-    plotting.plot_snr_vs_signal(
-        np.array([1.0]), np.array([2.0]), {}, tmp_path / "out.png"
-    )
-    assert (tmp_path / "out.png").is_file()
 
 
 def test_plot_snr_vs_signal_multi(tmp_path):


### PR DESCRIPTION
## Summary
- remove the unused `plot_snr_vs_signal` function
- drop tests that depended on it

## Testing
- `black core/plotting.py tests/test_plotting.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68407dce6690833392e074ac3c5d1472