### PR TITLE
Clip low SNR values when collecting gain curves

### DIFF
--- a/core/analysis.py
+++ b/core/analysis.py
@@ -813,6 +813,8 @@ def collect_gain_snr_signal(
         gain = float(row.get("Gain (dB)", 0.0))
         black = 0.0 if black_levels is None else float(black_levels.get(gain, 0.0))
         snr = (mean - black) / std
+        if snr < 1.0:
+            snr = 1.0
         data.setdefault(gain, []).append((mean, snr))
 
     res: Dict[float, tuple[np.ndarray, np.ndarray]] = {}

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -109,6 +109,24 @@ def test_collect_gain_snr_signal_rows():
     assert np.allclose(snr, [9.0, 9.5])
 
 
+def test_collect_gain_snr_signal_clips_low_snr():
+    rows = [
+        {
+            "ROI Type": "grayscale",
+            "ROI No": 0,
+            "Gain (dB)": 0.0,
+            "Exposure": 1.0,
+            "Mean": 1.0,
+            "Std": 2.0,
+        }
+    ]
+    cfg = {"processing": {"exclude_abnormal_snr": False, "min_sig_factor": 0}}
+    data = analysis.collect_gain_snr_signal(rows, cfg, {0.0: 0.0})
+    sig, snr = data[0.0]
+    assert np.allclose(sig, [1.0])
+    assert np.allclose(snr, [1.0])
+
+
 def test_collect_gain_noise_signal_rows():
     rows = [
         {


### PR DESCRIPTION
## Summary
- prevent negative or zero SNR values in `collect_gain_snr_signal`
- test clipping behavior when SNR is below one

## Testing
- `black core/analysis.py tests/test_analysis.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840881f6b4c8333ac945146f69ccabe