### PR TITLE
Improve SNR curve fitting

### DIFF
--- a/core/analysis.py
+++ b/core/analysis.py
@@ -1514,7 +1514,7 @@ def fit_snr_signal_model(
     adc_full_scale: float,
     black_level: float = 0.0,
     *,
-    num_points: int = 200,
+    num_points: int = 400,
 ) -> tuple[np.ndarray, np.ndarray]:
     """Return smoothed SNR curve using a robust P-spline fit."""
 

--- a/core/plotting.py
+++ b/core/plotting.py
@@ -87,8 +87,13 @@ def plot_snr_vs_signal_multi(
         xs, snr_fit = analysis.fit_snr_signal_model(
             sig, snr, adc_full_scale, black_level=bl
         )
+        snr_fit = np.maximum(snr_fit, 0.0)
         ax_snr.loglog(
-            xs, 20 * np.log10(snr_fit), linestyle="-", color=color, label="_nolegend_"
+            xs,
+            20 * np.log10(np.maximum(snr_fit, 1e-12)),
+            linestyle="-",
+            color=color,
+            label="_nolegend_",
         )
 
     if all_signals:

--- a/core/report_gen.py
+++ b/core/report_gen.py
@@ -216,6 +216,7 @@ def save_snr_signal_json(
             xs, snr_fit = analysis.fit_snr_signal_model(
                 sig, snr, full_scale, black_level=bl
             )
+            snr_fit = np.maximum(snr_fit, 0.0)
             out[f"{gain:g}"] = {
                 "signal": sig.tolist(),
                 "snr": snr.tolist(),

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -606,6 +606,6 @@ def test_fit_three_region_snr_model_basic():
     sig = np.linspace(0, 100, 20)
     snr = analysis.clipped_snr_model(sig, 2.0, 100.0)
     xs, fit = analysis.fit_snr_signal_model(sig, snr, 100.0)
-    assert xs.shape == (200,)
-    assert fit.shape == (200,)
+    assert xs.shape == (400,)
+    assert fit.shape == (400,)
     assert np.isfinite(fit).all()

--- a/tests/test_report_gen.py
+++ b/tests/test_report_gen.py
@@ -57,4 +57,4 @@ def test_save_snr_signal_json(tmp_path):
     txt = json.loads(out_file.read_text(encoding="utf-8"))
     assert "0" in txt
     assert txt["0"]["signal"][0] == pytest.approx(1.0)
-    assert len(txt["0"]["fit_signal"]) == 200
+    assert len(txt["0"]["fit_signal"]) == 400

--- a/tests/test_robust_pspline.py
+++ b/tests/test_robust_pspline.py
@@ -10,6 +10,6 @@ def test_robust_p_spline_simple():
     x_dense, y_pred, upper, lower = robust_p_spline_fit(
         x, y, deg=3, n_splines=15, lam=0.1, knot_density="uniform"
     )
-    assert x_dense.size == 200
+    assert x_dense.size == 400
     assert y_pred.shape == x_dense.shape
     assert np.all(upper >= lower)

--- a/utils/robust_pspline.py
+++ b/utils/robust_pspline.py
@@ -10,7 +10,7 @@ from scipy.linalg import cho_factor, cho_solve
 __all__ = ["robust_p_spline_fit", "plot_fit"]
 
 
-_DEF_LAM_RANGE = np.logspace(-2, 2, 8)
+_DEF_LAM_RANGE = np.logspace(-3, 2, 10)
 _DEF_N_RANGE = np.arange(10, 31, 5)
 
 


### PR DESCRIPTION
## Summary
- refine P-spline lambda search range
- use 400 points in `fit_snr_signal_model`
- clip negative SNR values when saving and plotting
- update tests for new resolution

## Testing
- `black core/analysis.py core/report_gen.py core/plotting.py utils/robust_pspline.py tests/test_analysis.py tests/test_report_gen.py tests/test_robust_pspline.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68408bdebb9c833397750221ffe81788