### PR TITLE
Enable configurable SNR fitting parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ x_dense, y_pred, upper, lower = robust_p_spline_fit(x, y)
 
 The resulting `x_dense` and `y_pred` arrays can be plotted to visualize the
 smoothed SNR curve, while `upper` and `lower` provide the confidence bounds.
+Parameters for the fitting routine can be tuned via the `processing.snr_fit`
+section in `config.yaml`.
 
 ##🔮 Planned Features
 

--- a/Sensor_Output_Spec.md
+++ b/Sensor_Output_Spec.md
@@ -73,6 +73,9 @@ Gainごとに下記項目を出力
   * DN\_satの基準：config.reference.sat\_factor
 * **DN @ SNR=10dB**：SNRカーブから、SNRが10dB（config.processing.snr\_threshold\_dB）を超える最小DN値をPスプライン回帰曲線から推定。
 * **DN @ SNR=1 (0 dB)**：SNRが1となる最小信号レベル（ノイズと等価）を同回帰曲線から推定。
+  * SNRカーブのロバストPスプライン回帰は `processing.snr_fit` セクションで
+    次のパラメータを調整できる:
+    `deg`, `n_splines`, `lam`, `knot_density`, `robust`, `num_points`。
 
 #### 2. `roi_stats.csv`
 
@@ -236,6 +239,13 @@ processing:
   read_noise_mode: 0          # 0:スタックstd, 1:差分std/√2
   prnu_fit: LS                # LS:最小二乗法 WLS:加重最小二乗法
   exclude_abnormal_snr: true  # SNRが極端に低いROIを除外
+  snr_fit:
+    deg: 3                # P-スプライン次数
+    n_splines: auto       # スプライン数または 'auto'
+    lam: null             # スムージング係数(nullで自動探索)
+    knot_density: auto    # 'auto' or 'uniform'
+    robust: huber         # ロバスト重み関数
+    num_points: 400       # 出力曲線のポイント数
 
 plot:
   exposures: [1.0, 0.0625]    # 図1に描画する露光倍率

--- a/config/default_config.yaml
+++ b/config/default_config.yaml
@@ -54,6 +54,13 @@ processing:
   read_noise_mode: 0               # 0: use std of stack, 1: use std of frame diff / √2
   prnu_fit: LS                     # LS or WLS regression method
   exclude_abnormal_snr: true       # Ignore low‑SNR patches
+  snr_fit:
+    deg: 3                        # Polynomial degree for P-spline fit
+    n_splines: auto               # Number of B-splines or 'auto'
+    lam: null                     # Smoothing parameter or null
+    knot_density: auto            # 'auto' or 'uniform'
+    robust: huber                 # Robust weight function
+    num_points: 400               # Points in fitted curve
 
 plot:
   # exposures: [4.0,2.0,1.0,0.5,0.25,0.125,0.0625]  # Override order if needed

--- a/core/analysis.py
+++ b/core/analysis.py
@@ -1533,6 +1533,11 @@ def fit_snr_signal_model(
     adc_full_scale: float,
     black_level: float = 0.0,
     *,
+    deg: int = 3,
+    n_splines: int | str = "auto",
+    lam: float | None = None,
+    knot_density: str = "auto",
+    robust: str = "huber",
     num_points: int = 400,
     max_signal: float | None = None,
 ) -> tuple[np.ndarray, np.ndarray]:
@@ -1540,6 +1545,18 @@ def fit_snr_signal_model(
 
     Parameters
     ----------
+    deg:
+        Spline degree.
+    n_splines:
+        Number of splines or ``"auto"`` for automatic selection.
+    lam:
+        Smoothing parameter. ``None`` lets the algorithm search a suitable value.
+    knot_density:
+        Knot placement strategy (``"auto"`` or ``"uniform"``).
+    robust:
+        Weighting method for robust fitting.
+    num_points:
+        Number of points in the returned curve.
     max_signal:
         Optional clipping threshold. Points above this value are ignored and
         the fitted curve is truncated accordingly.
@@ -1570,11 +1587,11 @@ def fit_snr_signal_model(
     xs, ys, _, _ = robust_p_spline_fit(
         signal,
         snr,
-        deg=3,
-        n_splines="auto",
-        lam=None,
-        knot_density="auto",
-        robust="huber",
+        deg=deg,
+        n_splines=n_splines,
+        lam=lam,
+        knot_density=knot_density,
+        robust=robust,
         num_points=num_points,
     )
 

--- a/core/plotting.py
+++ b/core/plotting.py
@@ -65,7 +65,9 @@ def plot_snr_vs_signal_multi(
     logging.info("plot_snr_vs_signal_multi: output=%s", output_path)
     log_memory_usage("plot start: ")
 
-    thresh = cfg.get("processing", {}).get("snr_threshold_dB", 10.0)
+    processing_cfg = cfg.get("processing", {})
+    snr_cfg = processing_cfg.get("snr_fit", {})
+    thresh = processing_cfg.get("snr_threshold_dB", 10.0)
     fig, ax_snr = plt.subplots()
 
     adc_full_scale = cfgutil.adc_full_scale(cfg)
@@ -106,7 +108,17 @@ def plot_snr_vs_signal_multi(
 
         bl = 0.0 if black_levels is None else float(black_levels.get(gain, 0.0))
         xs, snr_fit = analysis.fit_snr_signal_model(
-            sig_p, snr_p, adc_full_scale, black_level=bl, max_signal=limit
+            sig_p,
+            snr_p,
+            adc_full_scale,
+            black_level=bl,
+            deg=int(snr_cfg.get("deg", 3)),
+            n_splines=snr_cfg.get("n_splines", "auto"),
+            lam=snr_cfg.get("lam"),
+            knot_density=snr_cfg.get("knot_density", "auto"),
+            robust=snr_cfg.get("robust", "huber"),
+            num_points=int(snr_cfg.get("num_points", 400)),
+            max_signal=limit,
         )
         snr_fit = np.maximum(snr_fit, 0.0)
         ax_snr.loglog(

--- a/core/report_gen.py
+++ b/core/report_gen.py
@@ -213,6 +213,8 @@ def save_snr_signal_json(
     import numpy as np
     from . import analysis
 
+    proc_cfg = cfg.get("processing", {})
+    snr_cfg = proc_cfg.get("snr_fit", {})
     flag = cfg.get("output", {}).get("snr_signal_data", False)
 
     def writer(p: Path) -> None:
@@ -239,6 +241,12 @@ def save_snr_signal_json(
                 snr_use,
                 full_scale,
                 black_level=bl,
+                deg=int(snr_cfg.get("deg", 3)),
+                n_splines=snr_cfg.get("n_splines", "auto"),
+                lam=snr_cfg.get("lam"),
+                knot_density=snr_cfg.get("knot_density", "auto"),
+                robust=snr_cfg.get("robust", "huber"),
+                num_points=int(snr_cfg.get("num_points", 400)),
                 max_signal=limit,
             )
             snr_fit = np.maximum(snr_fit, 0.0)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -40,6 +40,7 @@ def test_load_config_merges_defaults(tmp_path):
     # default values preserved
     assert cfg["measurement"]["gains"]["6"]["folder"] == "gain_6dB"
     assert cfg["processing"]["min_sig_factor"] == 3
+    assert cfg["processing"]["snr_fit"]["num_points"] == 400
 
 
 def test_gain_entries_sorted():

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -63,14 +63,14 @@ def test_plot_snr_vs_signal_multi_interp(tmp_path):
     data = {0.0: (np.array([1.0, 3.0]), np.array([2.0, 6.0]))}
     fig = plotting.plot_snr_vs_signal_multi(
         data,
-        {},
+        {"processing": {"snr_fit": {"num_points": 5}}},
         tmp_path / "interp.png",
         return_fig=True,
         interp_points=5,
         black_levels={0.0: 0.0},
     )
     assert (tmp_path / "interp.png").is_file()
-    assert len(fig.axes[0].lines[0].get_xdata()) == 2
+    assert len(fig.axes[0].lines[1].get_xdata()) == 5
 
 
 def test_plot_snr_vs_signal_multi_invalid(tmp_path):

--- a/tests/test_report_gen.py
+++ b/tests/test_report_gen.py
@@ -45,7 +45,11 @@ def test_report_html_summary_text(tmp_path):
 
 
 def test_save_snr_signal_json(tmp_path):
-    cfg_data = {"output": {"snr_signal_data": True}, "sensor": {"adc_bits": 8}}
+    cfg_data = {
+        "output": {"snr_signal_data": True},
+        "sensor": {"adc_bits": 8},
+        "processing": {"snr_fit": {"num_points": 10}},
+    }
     cfg_file = tmp_path / "config.yaml"
     with cfg_file.open("w", encoding="utf-8") as fh:
         yaml.safe_dump(cfg_data, fh)
@@ -57,4 +61,4 @@ def test_save_snr_signal_json(tmp_path):
     txt = json.loads(out_file.read_text(encoding="utf-8"))
     assert "0" in txt
     assert txt["0"]["signal"][0] == pytest.approx(1.0)
-    assert len(txt["0"]["fit_signal"]) == 400
+    assert len(txt["0"]["fit_signal"]) == 10


### PR DESCRIPTION
## Summary
- add `processing.snr_fit` defaults to config
- make `analysis.fit_snr_signal_model` accept spline parameters
- wire plotting and report generation to use new config values
- update documentation with new section
- test configurable SNR fit behaviour

## Testing
- `black . --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840982267108333ade8ad655b3de057