### PR TITLE
Update SNR fit documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,11 @@ The resulting `x_dense` and `y_pred` arrays can be plotted to visualize the
 smoothed SNR curve, while `upper` and `lower` provide the confidence bounds.
 Parameters for the fitting routine can be tuned via the `processing.snr_fit`
 section in `config.yaml`.
+代表的なパラメータの目安は以下の通りです。
+  * `lam` を `null` にすると 1e-3〜1e2 の範囲で自動探索します
+  * `n_splines` を `auto` にすると 10〜30 の範囲から最適値を選びます
+  * `deg` は `n_splines` より小さい値に設定してください
+
 
 ##🔮 Planned Features
 

--- a/Sensor_Output_Spec.md
+++ b/Sensor_Output_Spec.md
@@ -246,6 +246,9 @@ processing:
     knot_density: auto    # 'auto' or 'uniform'
     robust: huber         # ロバスト重み関数
     num_points: 400       # 出力曲線のポイント数
+  * `lam` null なら 1e-3〜1e2 の範囲を自動探索
+  * `n_splines` auto なら 10〜30 本を候補とする
+  * `deg` は `n_splines` より小さく設定
 
 plot:
   exposures: [1.0, 0.0625]    # 図1に描画する露光倍率


### PR DESCRIPTION
## Summary
- document typical parameter ranges for robust P-spline fitting
- add recommended ranges for `processing.snr_fit` settings

## Testing
- `black . --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68409ea06ef083339e79e9562794ae42