### PR TITLE
Handle black level in SNR fit

### DIFF
--- a/core/analysis.py
+++ b/core/analysis.py
@@ -1559,7 +1559,7 @@ def fit_snr_signal_model(
         the fitted curve is truncated accordingly.
     """
 
-    signal = np.asarray(signal, dtype=float)
+    signal = np.asarray(signal, dtype=float) - black_level
     snr = np.asarray(snr, dtype=float)
 
     mask = np.isfinite(signal) & np.isfinite(snr)

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -629,3 +629,29 @@ def test_fit_three_region_snr_model_basic():
     assert xs.shape == (400,)
     assert fit.shape == (400,)
     assert np.isfinite(fit).all()
+
+
+def test_fit_snr_signal_model_black_level_shift():
+    sig = np.linspace(10.0, 110.0, 20)
+    black = 10.0
+    snr = analysis.clipped_snr_model(sig, 1.0, 120.0, black_level=black)
+    xs1, fit1 = analysis.fit_snr_signal_model(
+        sig,
+        snr,
+        120.0,
+        black_level=black,
+        n_splines=20,
+        lam=0.001,
+    )
+    xs2, fit2 = analysis.fit_snr_signal_model(
+        sig - black,
+        snr,
+        120.0 - black,
+        black_level=0.0,
+        n_splines=20,
+        lam=0.001,
+    )
+    assert np.allclose(xs1, xs2 + black)
+    assert np.allclose(fit1, fit2)
+    interp = np.interp(sig, xs1, fit1)
+    assert np.allclose(interp, snr, rtol=0.05)


### PR DESCRIPTION
## Summary
- account for black level when fitting SNR vs. signal
- test that SNR fitting with black level applied returns values in raw DN

## Testing
- `black core/analysis.py tests/test_analysis.py --check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841bae797f08333a26222b6a2736e41