### PR TITLE
Unify ROI handling for DN metrics

### DIFF
--- a/Sensor_Output_Spec.md
+++ b/Sensor_Output_Spec.md
@@ -71,8 +71,8 @@ Gainごとに下記項目を出力
 * **Dynamic Range (dB)**：最大信号値として DN\_sat を用い、Read Noise (DN) との比から 20\*log10(DN\_sat / Noise) を算出。
 * **SNR @ 50%**：グレースケールチャートまたはフラット画像で、Full-Wellの50%（例：32768 DN）に最も近いμとSNRの系列から、`utils.robust_pspline.robust_p_spline_fit` を利用したロバストPスプライン回帰で推定して算出。
   * DN\_satの基準：config.reference.sat\_factor
-* **DN @ SNR=10dB**：SNRカーブから、SNRが10dB（config.processing.snr\_threshold\_dB）を超える最小DN値をPスプライン回帰曲線から推定。
-* **DN @ SNR=1 (0 dB)**：SNRが1となる最小信号レベル（ノイズと等価）を同回帰曲線から推定。
+* **DN @ SNR=10dB**：SNRカーブから、SNRが10dB（config.processing.snr_threshold_dB）を超える最小DN値をPスプライン回帰曲線から推定。SNRカーブはグレーチャートROIとフラットROIの全てを用いる。
+* **DN @ SNR=1 (0 dB)**：SNRが1となる最小信号レベル（ノイズと等価）を同回帰曲線から推定。SNRカーブは上記と同じく全ROIを使用する。
   * SNRカーブのロバストPスプライン回帰は `processing.snr_fit` セクションで
     次のパラメータを調整できる:
     `deg`, `n_splines`, `lam`, `knot_density`, `robust`, `num_points`。
@@ -120,6 +120,7 @@ GUI上、および出力画像として出力
   * 横軸：ROI平均信号（DN）
   * 対象：Flat画像と グレーチャート画像の両方のROIを使用してμ-SNR系列を構成
   * 縦軸：SNR（dB）
+  * このSNR-Signal曲線は summary.txt の DN 指標計算にも共通で使用する。
   * 系列：Gainごと色分け
   * 補助線：理想曲線（√μ）、SNR=10dBライン
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -92,3 +92,78 @@ def test_run_pipeline_returns_summary(tmp_path):
     assert "summary" in result
     assert "Dynamic Range (dB)" in result["summary"]
     assert isinstance(result["summary"]["Dynamic Range (dB)"], float)
+
+
+def test_dn_at_10_uses_all_roi(tmp_path):
+    project = tmp_path
+
+    chart1 = project / "gain_0dB" / "chart_1x"
+    chart2 = project / "gain_0dB" / "chart_x2"
+    flat_dir = project / "gain_0dB" / "flat"
+    dark_dir = project / "gain_0dB" / "dark"
+
+    _write_stack(
+        chart1, np.stack([np.full((2, 2), 1, np.uint16), np.full((2, 2), 5, np.uint16)])
+    )
+    _write_stack(
+        chart2, np.stack([np.full((2, 2), 2, np.uint16), np.full((2, 2), 6, np.uint16)])
+    )
+    _write_stack(
+        flat_dir,
+        np.stack([np.full((2, 2), 20, np.uint16), np.full((2, 2), 24, np.uint16)]),
+    )
+    _write_stack(
+        dark_dir, np.stack([np.zeros((2, 2), np.uint16), np.zeros((2, 2), np.uint16)])
+    )
+
+    roi_file = project / "roi.roi"
+    roi_file.write_text("dummy")
+
+    cfg_data = {
+        "measurement": {
+            "gains": {0: {"folder": "gain_0dB"}},
+            "exposures": {
+                1.0: {"folder": "chart_1x"},
+                2.0: {"folder": "chart_x2"},
+                1.5: {"folder": "flat"},
+            },
+            "flat_lens_folder": "flat",
+            "dark_folder": "dark",
+            "chart_roi_file": str(roi_file),
+            "flat_roi_file": str(roi_file),
+            "roi_mid_index": 0,
+        },
+        "processing": {
+            "stat_mode": "mean",
+            "min_sig_factor": 0,
+            "exclude_abnormal_snr": False,
+            "gain_map_mode": "none",
+            "snr_fit": {"num_points": 5},
+        },
+        "output": {
+            "report_html": False,
+            "report_csv": False,
+            "report_summary": False,
+            "output_dir": "out",
+            "snr_signal_data": False,
+        },
+        "illumination": {"power_uW_cm2": 100.0, "exposure_ms": 50},
+        "sensor": {"adc_bits": 10, "lsb_shift": 0},
+    }
+
+    cfg_file = project / "config.yaml"
+    with cfg_file.open("w", encoding="utf-8") as fh:
+        import yaml
+
+        yaml.safe_dump(cfg_data, fh)
+
+    cfg = load_config(cfg_file)
+    cfg["measurement"]["gains"] = {"0": {"folder": "gain_0dB"}}
+    cfg["measurement"]["exposures"] = {
+        "1.0": {"folder": "chart_1x"},
+        "2.0": {"folder": "chart_x2"},
+        "1.5": {"folder": "flat"},
+    }
+    result = run_pipeline(project, cfg)
+    val = result["summary"]["DN @ 10 dB"]
+    assert val == pytest.approx(6.32, rel=0.05)


### PR DESCRIPTION
## Summary
- compute DN metrics from SNR–Signal curves including all ROI
- document unified behaviour in output spec
- test DN@10dB calculation using full ROI set

## Testing
- `black core/pipeline.py tests/test_pipeline.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841ebb7d2c4833395058b6aef8fb13e