### PR TITLE
Update SNR threshold plotting

### DIFF
--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -181,7 +181,11 @@ def test_plot_snr_vs_signal_multi_threshold_lines(tmp_path):
         black_levels={0.0: 0.0},
     )
     ax = fig.axes[0]
-    dotted = [l for l in ax.lines if l.get_linestyle() == ":"]
-    assert any(
-        len(l.get_xdata()) == 2 and l.get_xdata()[0] != l.get_xdata()[1] for l in dotted
-    )
+    dotted = [
+        l
+        for l in ax.lines
+        if l.get_linestyle() == ":"
+        and len(l.get_xdata()) == 2
+        and l.get_xdata()[0] != l.get_xdata()[1]
+    ]
+    assert len(dotted) == 1


### PR DESCRIPTION
## Summary
- refactor SNR threshold extrapolation so a single dotted segment connects the 0 dB and configured threshold crossings
- adjust test to expect one dotted threshold line

## Testing
- `black core/plotting.py tests/test_plotting.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842c35694188333a8f5351f26f13f08