### PR TITLE
Improve DN saturation estimation

### DIFF
--- a/core/analysis.py
+++ b/core/analysis.py
@@ -1088,10 +1088,13 @@ def _estimate_sat_from_noise(
 ) -> float:
     """Return ``DN_sat`` estimated from the noise curve.
 
-    ``DN_sat`` is computed as ``ADC_full_scale`` minus the noise value at the
-    last point where the noise, scanned from the largest signal value,
-    monotonically increases and then turns to decrease. If such a point cannot
-    be found, ``ADC_full_scale`` minus the maximum noise is used instead.
+    Starting from the point with the largest signal, the noise values are
+    scanned backwards. At each step, the previous three points are inspected.
+    If any noise value in that window is greater than the current one, the
+    search jumps to the index of that higher value and continues. Once no
+    larger value exists within the window, the current noise is used as the
+    turning point. If no suitable turning point can be found, the maximum noise
+    value is used instead.
     """
 
     if signal.size < 2 or noise.size != signal.size:
@@ -1100,11 +1103,17 @@ def _estimate_sat_from_noise(
     idx = np.argsort(signal)
     n = np.asarray(noise, dtype=float)[idx]
 
-    turn_noise = None
-    for i in range(n.size - 1, 0, -1):
-        if n[i - 1] < n[i]:
-            turn_noise = float(n[i])
-            break
+    turn_noise: float | None = None
+
+    i = n.size - 1
+    while i > 0:
+        start = max(0, i - 3)
+        window = n[start:i]
+        if window.size and np.any(window > n[i]):
+            i = start + int(np.argmax(window))
+            continue
+        turn_noise = float(n[i])
+        break
 
     if turn_noise is None:
         turn_noise = float(n.max())

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -683,3 +683,10 @@ def test_calculate_dn_at_snr_polyfit_extrapolation_high():
     snr = np.array([1.0, 2.0, 3.0])
     val = analysis.calculate_dn_at_snr_polyfit(sig, snr, 10.0)
     assert val == pytest.approx(31.6227766016, rel=1e-6)
+
+
+def test_estimate_sat_from_noise_fluctuations():
+    signal = np.arange(8) * 10.0
+    noise = np.array([1.0, 2.0, 3.0, 2.8, 2.9, 2.7, 2.5, 2.4])
+    dn_sat = analysis._estimate_sat_from_noise(signal, noise, 100.0)
+    assert dn_sat == pytest.approx(97.0)


### PR DESCRIPTION
## Summary
- refine `_estimate_sat_from_noise` to backtrack using a 3-sample window
- document the new algorithm
- add regression test for noise curve fluctuations

## Testing
- `black core/analysis.py tests/test_analysis.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842d8904de48333a970987b4b33653f